### PR TITLE
Contracts: Model custom errors

### DIFF
--- a/packages/authorizer/contracts/Authorized.sol
+++ b/packages/authorizer/contracts/Authorized.sol
@@ -84,7 +84,7 @@ contract Authorized is IAuthorized, Initializable, AuthorizedHelpers {
      * @param how Params to be authenticated
      */
     function _authenticate(address who, bytes4 what, uint256[] memory how) internal view {
-        require(_isAuthorized(who, what, how), 'AUTH_SENDER_NOT_ALLOWED');
+        if (!_isAuthorized(who, what, how)) revert AuthSenderNotAllowed(who, what, how);
     }
 
     /**

--- a/packages/authorizer/contracts/Authorizer.sol
+++ b/packages/authorizer/contracts/Authorizer.sol
@@ -165,7 +165,7 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
     function authorize(address who, address where, bytes4 what, Param[] memory params) public override nonReentrant {
         uint256[] memory how = authParams(who, where, what);
         bool allowed = isAuthorized(msg.sender, address(this), IAuthorizer.authorize.selector, how);
-        require(allowed, 'AUTHORIZER_SENDER_NOT_ALLOWED');
+        if (!allowed) revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.authorize.selector, how);
         _authorize(who, where, what, params);
     }
 
@@ -178,7 +178,7 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
     function unauthorize(address who, address where, bytes4 what) public override nonReentrant {
         uint256[] memory how = authParams(who, where, what);
         bool allowed = isAuthorized(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
-        require(allowed, 'AUTHORIZER_SENDER_NOT_ALLOWED');
+        if (!allowed) revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
         _unauthorize(who, where, what);
     }
 
@@ -255,6 +255,6 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
         if (Op(param.op) == Op.LT) return how < param.value;
         if (Op(param.op) == Op.GTE) return how >= param.value;
         if (Op(param.op) == Op.LTE) return how <= param.value;
-        revert('AUTHORIZER_INVALID_PARAM_OP');
+        revert AuthorizerInvalidParamOp(param.op);
     }
 }

--- a/packages/authorizer/contracts/Authorizer.sol
+++ b/packages/authorizer/contracts/Authorizer.sol
@@ -164,8 +164,7 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
      */
     function authorize(address who, address where, bytes4 what, Param[] memory params) public override nonReentrant {
         uint256[] memory how = authParams(who, where, what);
-        bool allowed = isAuthorized(msg.sender, address(this), IAuthorizer.authorize.selector, how);
-        if (!allowed) revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.authorize.selector, how);
+        _authenticate(msg.sender, IAuthorizer.authorize.selector, how);
         _authorize(who, where, what, params);
     }
 
@@ -177,10 +176,19 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
      */
     function unauthorize(address who, address where, bytes4 what) public override nonReentrant {
         uint256[] memory how = authParams(who, where, what);
-        bool allowed = isAuthorized(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
-        if (!allowed)
-            revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
+        _authenticate(msg.sender, IAuthorizer.unauthorize.selector, how);
         _unauthorize(who, where, what);
+    }
+
+    /**
+     * @dev Validates whether `who` is authorized to call `what` with `how`
+     * @param who Address asking permission for
+     * @param what Function selector asking permission for
+     * @param how Params asking permission for
+     */
+    function _authenticate(address who, bytes4 what, uint256[] memory how) internal view {
+        bool allowed = isAuthorized(who, address(this), what, how);
+        if (!allowed) revert AuthorizerSenderNotAllowed(who, address(this), what, how);
     }
 
     /**

--- a/packages/authorizer/contracts/Authorizer.sol
+++ b/packages/authorizer/contracts/Authorizer.sol
@@ -178,7 +178,8 @@ contract Authorizer is IAuthorizer, AuthorizedHelpers, Initializable, Reentrancy
     function unauthorize(address who, address where, bytes4 what) public override nonReentrant {
         uint256[] memory how = authParams(who, where, what);
         bool allowed = isAuthorized(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
-        if (!allowed) revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
+        if (!allowed)
+            revert AuthorizerSenderNotAllowed(msg.sender, address(this), IAuthorizer.unauthorize.selector, how);
         _unauthorize(who, where, what);
     }
 

--- a/packages/authorizer/contracts/interfaces/IAuthorized.sol
+++ b/packages/authorizer/contracts/interfaces/IAuthorized.sol
@@ -19,6 +19,11 @@ pragma solidity >=0.8.0;
  */
 interface IAuthorized {
     /**
+     * @dev `who` is not allowed to call `what` with `how`
+     */
+    error AuthSenderNotAllowed(address who, bytes4 what, uint256[] how);
+
+    /**
      * @dev Tells the address of the authorizer reference
      */
     function authorizer() external view returns (address);

--- a/packages/authorizer/contracts/interfaces/IAuthorized.sol
+++ b/packages/authorizer/contracts/interfaces/IAuthorized.sol
@@ -19,7 +19,7 @@ pragma solidity >=0.8.0;
  */
 interface IAuthorized {
     /**
-     * @dev `who` is not allowed to call `what` with `how`
+     * @dev Sender `who` is not allowed to call `what` with `how`
      */
     error AuthSenderNotAllowed(address who, bytes4 what, uint256[] how);
 

--- a/packages/authorizer/contracts/interfaces/IAuthorizer.sol
+++ b/packages/authorizer/contracts/interfaces/IAuthorizer.sol
@@ -67,19 +67,19 @@ interface IAuthorizer {
     error AuthorizerSenderNotAllowed(address who, address where, bytes4 what, uint256[] how);
 
     /**
-     * @dev The param operation is invalid
+     * @dev The operation param is invalid
      */
     error AuthorizerInvalidParamOp(uint8 op);
 
     /**
      * @dev Emitted every time `who`'s permission to perform `what` on `where` is granted with `params`
      */
-    event Authorized(address who, address where, bytes4 indexed what, Param[] params);
+    event Authorized(address indexed who, address indexed where, bytes4 indexed what, Param[] params);
 
     /**
      * @dev Emitted every time `who`'s permission to perform `what` on `where` is revoked
      */
-    event Unauthorized(address who, address where, bytes4 indexed what);
+    event Unauthorized(address indexed who, address indexed where, bytes4 indexed what);
 
     /**
      * @dev Tells whether `who` has any permission on `where`

--- a/packages/authorizer/contracts/interfaces/IAuthorizer.sol
+++ b/packages/authorizer/contracts/interfaces/IAuthorizer.sol
@@ -62,14 +62,24 @@ interface IAuthorizer {
     }
 
     /**
+     * @dev Sender is not authorized to call `what` on `where` with `how`
+     */
+    error AuthorizerSenderNotAllowed(address who, address where, bytes what, uint256[] how);
+
+    /**
+     * @dev The param operation is invalid
+     */
+    error AuthorizerInvalidParamOp(uint8 op);
+
+    /**
      * @dev Emitted every time `who`'s permission to perform `what` on `where` is granted with `params`
      */
-    event Authorized(address indexed who, address indexed where, bytes4 indexed what, Param[] params);
+    event Authorized(address who, address where, bytes4 indexed what, Param[] params);
 
     /**
      * @dev Emitted every time `who`'s permission to perform `what` on `where` is revoked
      */
-    event Unauthorized(address indexed who, address indexed where, bytes4 indexed what);
+    event Unauthorized(address who, address where, bytes4 indexed what);
 
     /**
      * @dev Tells whether `who` has any permission on `where`

--- a/packages/authorizer/contracts/interfaces/IAuthorizer.sol
+++ b/packages/authorizer/contracts/interfaces/IAuthorizer.sol
@@ -64,7 +64,7 @@ interface IAuthorizer {
     /**
      * @dev Sender is not authorized to call `what` on `where` with `how`
      */
-    error AuthorizerSenderNotAllowed(address who, address where, bytes what, uint256[] how);
+    error AuthorizerSenderNotAllowed(address who, address where, bytes4 what, uint256[] how);
 
     /**
      * @dev The param operation is invalid

--- a/packages/authorizer/test/Authorizer.test.ts
+++ b/packages/authorizer/test/Authorizer.test.ts
@@ -385,17 +385,17 @@ describe('Authorizer', () => {
 
                 // try granting other permissions
                 await expect(authorizer.connect(who).authorize(WHO, WHERE2, WHAT, [])).to.be.revertedWith(
-                  'AUTHORIZER_SENDER_NOT_ALLOWED'
+                  'AuthorizerSenderNotAllowed'
                 )
                 await expect(authorizer.connect(who).authorize(WHO, WHERE, WHAT2, [])).to.be.revertedWith(
-                  'AUTHORIZER_SENDER_NOT_ALLOWED'
+                  'AuthorizerSenderNotAllowed'
                 )
 
                 // rollback authorization
                 await authorizer.unauthorize(who.address, authorizer.address, authorizeRole)
                 expect(await authorizer.isAuthorized(who.address, authorizer.address, authorizeRole, [])).to.be.false
                 await expect(authorizer.connect(who).authorize(WHO, WHERE, WHAT, [])).to.be.revertedWith(
-                  'AUTHORIZER_SENDER_NOT_ALLOWED'
+                  'AuthorizerSenderNotAllowed'
                 )
               })
             })
@@ -437,7 +437,7 @@ describe('Authorizer', () => {
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(authorizer.authorize(WHO, WHERE, WHAT, [])).to.be.revertedWith('AUTHORIZER_SENDER_NOT_ALLOWED')
+        await expect(authorizer.authorize(WHO, WHERE, WHAT, [])).to.be.revertedWith('AuthorizerSenderNotAllowed')
       })
     })
   })
@@ -502,7 +502,7 @@ describe('Authorizer', () => {
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(authorizer.unauthorize(WHO, WHERE, WHAT)).to.be.revertedWith('AUTHORIZER_SENDER_NOT_ALLOWED')
+        await expect(authorizer.unauthorize(WHO, WHERE, WHAT)).to.be.revertedWith('AuthorizerSenderNotAllowed')
       })
     })
   })
@@ -560,7 +560,7 @@ describe('Authorizer', () => {
           authorizer
             .connect(admin)
             .changePermissions([{ where: WHERE2, grants: [{ who: WHO2, what: WHAT2, params: [] }], revokes: [] }])
-        ).to.be.revertedWith('AUTHORIZER_SENDER_NOT_ALLOWED')
+        ).to.be.revertedWith('AuthorizerSenderNotAllowed')
       })
     })
   })

--- a/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
+++ b/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
@@ -26,6 +26,26 @@ import './IAxelarGateway.sol';
  * @dev Interfaces with Axelar to bridge tokens
  */
 contract AxelarConnector {
+    /**
+     * @dev The chain ID is the same of the current chain
+     */
+    error AxelarBridgeSameChain(uint256 chainId);
+
+    /**
+     * @dev The recipient address is zero
+     */
+    error AxelarBridgeRecipientZero();
+
+    /**
+     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     */
+    error AxelarBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    /**
+     * @dev The chain ID is not supported
+     */
+    error AxelarBridgeUnknownChainId(uint256 chainId);
+
     // List of chain names supported by Axelar
     string private constant ETHEREUM_NAME = 'Ethereum';
     string private constant POLYGON_NAME = 'Polygon';
@@ -61,8 +81,8 @@ contract AxelarConnector {
      * @param recipient Address that will receive the tokens on the destination chain
      */
     function execute(uint256 chainId, address token, uint256 amountIn, address recipient) external {
-        require(block.chainid != chainId, 'AXELAR_BRIDGE_SAME_CHAIN');
-        require(recipient != address(0), 'AXELAR_BRIDGE_RECIPIENT_ZERO');
+        if (block.chainid == chainId) revert AxelarBridgeSameChain(chainId);
+        if (recipient == address(0)) revert AxelarBridgeRecipientZero();
 
         string memory chainName = _getChainName(chainId);
         string memory symbol = IERC20Metadata(token).symbol();
@@ -73,7 +93,7 @@ contract AxelarConnector {
         axelarGateway.sendToken(chainName, Strings.toHexString(recipient), symbol, amountIn);
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        require(postBalanceIn >= preBalanceIn - amountIn, 'AXELAR_BAD_TOKEN_IN_BALANCE');
+        if (postBalanceIn < preBalanceIn - amountIn) revert AxelarBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**
@@ -88,6 +108,6 @@ contract AxelarConnector {
         else if (chainId == BSC_ID) return BSC_NAME;
         else if (chainId == FANTOM_ID) return FANTOM_NAME;
         else if (chainId == AVALANCHE_ID) return AVALANCHE_NAME;
-        else revert('AXELAR_UNKNOWN_CHAIN_ID');
+        else revert AxelarBridgeUnknownChainId(chainId);
     }
 }

--- a/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
+++ b/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
@@ -27,7 +27,7 @@ import './IAxelarGateway.sol';
  */
 contract AxelarConnector {
     /**
-     * @dev The chain ID is the same of the current chain
+     * @dev The source and destination chains are the same
      */
     error AxelarBridgeSameChain(uint256 chainId);
 
@@ -37,9 +37,9 @@ contract AxelarConnector {
     error AxelarBridgeRecipientZero();
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token balance is lower than the previous token balance minus the amount bridged
      */
-    error AxelarBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+    error AxelarBridgeBadPostTokenBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
 
     /**
      * @dev The chain ID is not supported
@@ -94,7 +94,7 @@ contract AxelarConnector {
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
         if (postBalanceIn < preBalanceIn - amountIn)
-            revert AxelarBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+            revert AxelarBridgeBadPostTokenBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
+++ b/packages/connectors/contracts/bridge/axelar/AxelarConnector.sol
@@ -93,7 +93,8 @@ contract AxelarConnector {
         axelarGateway.sendToken(chainName, Strings.toHexString(recipient), symbol, amountIn);
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert AxelarBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert AxelarBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
+++ b/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
@@ -102,7 +102,8 @@ contract ConnextConnector {
         if (block.chainid == chainId) revert ConnextBridgeSameChain(chainId);
         if (recipient == address(0)) revert ConnextBridgeRecipientZero();
         if (relayerFee > amountIn) revert ConnextBridgeRelayerFeeGTAmount(relayerFee, amountIn);
-        if (minAmountOut > amountIn - relayerFee) revert ConnextBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
+        if (minAmountOut > amountIn - relayerFee)
+            revert ConnextBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
 
         uint32 domain = _getChainDomain(chainId);
         uint256 amountInAfterFees = amountIn - relayerFee;
@@ -126,7 +127,8 @@ contract ConnextConnector {
         );
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert ConnextBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert ConnextBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
+++ b/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
@@ -25,6 +25,36 @@ import './IConnext.sol';
  * @dev Interfaces with Connext to bridge tokens
  */
 contract ConnextConnector {
+    /**
+     * @dev The chain ID is the same of the current chain
+     */
+    error ConnextBridgeSameChain(uint256 chainId);
+
+    /**
+     * @dev The recipient address is zero
+     */
+    error ConnextBridgeRecipientZero();
+
+    /**
+     * @dev The relayer fee is greater than the amount to be bridged
+     */
+    error ConnextBridgeRelayerFeeGTAmount(uint256 relayerFee, uint256 amountIn);
+
+    /**
+     * @dev The minimum amount out is greater than the amount to be bridged minus the relayer fee
+     */
+    error ConnextBridgeMinAmountOutTooBig(uint256 minAmountOut, uint256 amountIn, uint256 relayerFee);
+
+    /**
+     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     */
+    error ConnextBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    /**
+     * @dev The chain ID is not supported
+     */
+    error ConnextBridgeUnknownChainId(uint256 chainId);
+
     // List of chain domains supported by Connext
     uint32 private constant ETHEREUM_DOMAIN = 6648936;
     uint32 private constant POLYGON_DOMAIN = 1886350457;
@@ -69,10 +99,10 @@ contract ConnextConnector {
         address recipient,
         uint256 relayerFee
     ) external {
-        require(block.chainid != chainId, 'CONNEXT_BRIDGE_SAME_CHAIN');
-        require(recipient != address(0), 'CONNEXT_BRIDGE_RECIPIENT_ZERO');
-        require(relayerFee <= amountIn, 'CONNEXT_RELAYER_FEE_GT_AMOUNT_IN');
-        require(minAmountOut <= amountIn - relayerFee, 'CONNEXT_MIN_AMOUNT_OUT_TOO_BIG');
+        if (block.chainid == chainId) revert ConnextBridgeSameChain(chainId);
+        if (recipient == address(0)) revert ConnextBridgeRecipientZero();
+        if (relayerFee > amountIn) revert ConnextBridgeRelayerFeeGTAmount(relayerFee, amountIn);
+        if (minAmountOut > amountIn - relayerFee) revert ConnextBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
 
         uint32 domain = _getChainDomain(chainId);
         uint256 amountInAfterFees = amountIn - relayerFee;
@@ -96,7 +126,7 @@ contract ConnextConnector {
         );
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        require(postBalanceIn >= preBalanceIn - amountIn, 'CONNEXT_BAD_TOKEN_IN_BALANCE');
+        if (postBalanceIn < preBalanceIn - amountIn) revert ConnextBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**
@@ -111,6 +141,6 @@ contract ConnextConnector {
         else if (chainId == OPTIMISM_ID) return OPTIMISM_DOMAIN;
         else if (chainId == GNOSIS_ID) return GNOSIS_DOMAIN;
         else if (chainId == BSC_ID) return BSC_DOMAIN;
-        else revert('CONNEXT_UNKNOWN_CHAIN_ID');
+        else revert ConnextBridgeUnknownChainId(chainId);
     }
 }

--- a/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
+++ b/packages/connectors/contracts/bridge/connext/ConnextConnector.sol
@@ -26,7 +26,7 @@ import './IConnext.sol';
  */
 contract ConnextConnector {
     /**
-     * @dev The chain ID is the same of the current chain
+     * @dev The source and destination chains are the same
      */
     error ConnextBridgeSameChain(uint256 chainId);
 
@@ -38,7 +38,7 @@ contract ConnextConnector {
     /**
      * @dev The relayer fee is greater than the amount to be bridged
      */
-    error ConnextBridgeRelayerFeeGTAmount(uint256 relayerFee, uint256 amountIn);
+    error ConnextBridgeRelayerFeeGtAmount(uint256 relayerFee, uint256 amountIn);
 
     /**
      * @dev The minimum amount out is greater than the amount to be bridged minus the relayer fee
@@ -46,9 +46,9 @@ contract ConnextConnector {
     error ConnextBridgeMinAmountOutTooBig(uint256 minAmountOut, uint256 amountIn, uint256 relayerFee);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token balance is lower than the previous token balance minus the amount bridged
      */
-    error ConnextBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+    error ConnextBridgeBadPostTokenBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
 
     /**
      * @dev The chain ID is not supported
@@ -101,7 +101,7 @@ contract ConnextConnector {
     ) external {
         if (block.chainid == chainId) revert ConnextBridgeSameChain(chainId);
         if (recipient == address(0)) revert ConnextBridgeRecipientZero();
-        if (relayerFee > amountIn) revert ConnextBridgeRelayerFeeGTAmount(relayerFee, amountIn);
+        if (relayerFee > amountIn) revert ConnextBridgeRelayerFeeGtAmount(relayerFee, amountIn);
         if (minAmountOut > amountIn - relayerFee)
             revert ConnextBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
 
@@ -128,7 +128,7 @@ contract ConnextConnector {
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
         if (postBalanceIn < preBalanceIn - amountIn)
-            revert ConnextBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+            revert ConnextBridgeBadPostTokenBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/hop/HopConnector.sol
+++ b/packages/connectors/contracts/bridge/hop/HopConnector.sol
@@ -34,7 +34,7 @@ contract HopConnector {
     using Denominations for address;
 
     /**
-     * @dev The chain ID is the same of the current chain
+     * @dev The source and destination chains are the same
      */
     error HopBridgeSameChain(uint256 chainId);
 
@@ -46,12 +46,12 @@ contract HopConnector {
     /**
      * @dev The relayer was sent when not needed
      */
-    error HopRelayerNotNeeded();
+    error HopBridgeRelayerNotNeeded();
 
     /**
      * @dev The deadline was sent when not needed
      */
-    error HopDeadlineNotNeeded();
+    error HopBirdgeDeadlineNotNeeded();
 
     /**
      * @dev The bridge operation is not supported
@@ -59,19 +59,14 @@ contract HopConnector {
     error HopBridgeOpNotSupported();
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token balance is lower than the previous token balance minus the amount bridged
      */
-    error HopBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+    error HopBridgeBadPostTokenBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
 
     /**
-     * @dev The deadline is in the future
+     * @dev The deadline is in the past
      */
     error HopBridgeInvalidDeadline(uint256 deadline, uint256 blockTimestamp);
-
-    /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount in
-     */
-    error HopBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     // Ethereum mainnet chain ID = 1
     uint256 private constant MAINNET_CHAIN_ID = 1;
@@ -131,16 +126,16 @@ contract HopConnector {
         if (fromL1 && toL2)
             _bridgeFromL1ToL2(chainId, token, amountIn, minAmountOut, recipient, bridge, deadline, relayer, fee);
         else if (!fromL1 && toL2) {
-            if (relayer != address(0)) revert HopRelayerNotNeeded();
+            if (relayer != address(0)) revert HopBridgeRelayerNotNeeded();
             _bridgeFromL2ToL2(chainId, token, amountIn, minAmountOut, recipient, bridge, deadline, fee);
         } else if (!fromL1 && !toL2) {
-            if (deadline != 0) revert HopDeadlineNotNeeded();
+            if (deadline != 0) revert HopBirdgeDeadlineNotNeeded();
             _bridgeFromL2ToL1(chainId, token, amountIn, minAmountOut, recipient, bridge, fee);
         } else revert HopBridgeOpNotSupported();
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
         if (postBalanceIn < preBalanceIn - amountIn)
-            revert HopBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+            revert HopBridgeBadPostTokenBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/hop/HopConnector.sol
+++ b/packages/connectors/contracts/bridge/hop/HopConnector.sol
@@ -52,7 +52,7 @@ contract HopConnector {
      * @dev The deadline was sent when not needed
      */
     error HopDeadlineNotNeeded();
-    
+
     /**
      * @dev The bridge operation is not supported
      */
@@ -139,7 +139,8 @@ contract HopConnector {
         } else revert HopBridgeOpNotSupported();
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert HopBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert HopBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
+++ b/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
@@ -26,6 +26,36 @@ import './IWormhole.sol';
  * @dev Interfaces with Wormhole to bridge tokens through CCTP
  */
 contract WormholeConnector {
+    /**
+     * @dev The chain ID is the same of the current chain
+     */
+    error WormholeBridgeSameChain(uint256 chainId);
+
+    /**
+     * @dev The recipient address is zero
+     */
+    error WormholeBridgeRecipientZero();
+
+    /**
+     * @dev The relayer fee is greater than the amount to be bridged
+     */
+    error WormholeBridgeRelayerFeeGTAmount(uint256 relayerFee, uint256 amountIn);
+
+    /**
+     * @dev The minimum amount out is greater than the amount to be bridged minus the relayer fee
+     */
+    error WormholeBridgeMinAmountOutTooBig(uint256 minAmountOut, uint256 amountIn, uint256 relayerFee);
+
+    /**
+     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     */
+    error WormholeBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    /**
+     * @dev The chain ID is not supported
+     */
+    error WormholeBridgeUnknownChainId(uint256 chainId);
+
     // List of Wormhole network IDs
     uint16 private constant ETHEREUM_WORMHOLE_NETWORK_ID = 2;
     uint16 private constant POLYGON_WORMHOLE_NETWORK_ID = 5;
@@ -66,13 +96,13 @@ contract WormholeConnector {
     function execute(uint256 chainId, address token, uint256 amountIn, uint256 minAmountOut, address recipient)
         external
     {
-        require(block.chainid != chainId, 'WORMHOLE_BRIDGE_SAME_CHAIN');
-        require(recipient != address(0), 'WORMHOLE_BRIDGE_RECIPIENT_ZERO');
+        if (block.chainid == chainId) revert WormholeBridgeSameChain(chainId);
+        if (recipient == address(0)) revert WormholeBridgeRecipientZero();
 
         uint16 wormholeNetworkId = _getWormholeNetworkId(chainId);
         uint256 relayerFee = wormholeCircleRelayer.relayerFee(wormholeNetworkId, token);
-        require(relayerFee <= amountIn, 'WORMHOLE_RELAYER_FEE_GT_AMT_IN');
-        require(minAmountOut <= amountIn - relayerFee, 'WORMHOLE_MIN_AMOUNT_OUT_TOO_BIG');
+        if (relayerFee > amountIn) revert WormholeBridgeRelayerFeeGTAmount(relayerFee, amountIn);
+        if (minAmountOut > amountIn - relayerFee) revert WormholeBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
 
         uint256 preBalanceIn = IERC20(token).balanceOf(address(this));
 
@@ -86,13 +116,13 @@ contract WormholeConnector {
         );
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        require(postBalanceIn >= preBalanceIn - amountIn, 'WORMHOLE_BAD_TOKEN_IN_BALANCE');
+        if (postBalanceIn < preBalanceIn - amountIn) revert WormholeBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**
      * @dev Tells the Wormhole network ID based on a chain ID
      * @param chainId ID of the chain being queried
-     * @return Wormhole network ID associated to the requested chain ID
+     * @return Wormhole network ID associated with the requested chain ID
      */
     function _getWormholeNetworkId(uint256 chainId) internal pure returns (uint16) {
         if (chainId == ETHEREUM_ID) return ETHEREUM_WORMHOLE_NETWORK_ID;
@@ -102,6 +132,6 @@ contract WormholeConnector {
         else if (chainId == BSC_ID) return BSC_WORMHOLE_NETWORK_ID;
         else if (chainId == FANTOM_ID) return FANTOM_WORMHOLE_NETWORK_ID;
         else if (chainId == AVALANCHE_ID) return AVALANCHE_WORMHOLE_NETWORK_ID;
-        else revert('WORMHOLE_UNKNOWN_CHAIN_ID');
+        else revert WormholeBridgeUnknownChainId(chainId);
     }
 }

--- a/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
+++ b/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
@@ -102,7 +102,8 @@ contract WormholeConnector {
         uint16 wormholeNetworkId = _getWormholeNetworkId(chainId);
         uint256 relayerFee = wormholeCircleRelayer.relayerFee(wormholeNetworkId, token);
         if (relayerFee > amountIn) revert WormholeBridgeRelayerFeeGTAmount(relayerFee, amountIn);
-        if (minAmountOut > amountIn - relayerFee) revert WormholeBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
+        if (minAmountOut > amountIn - relayerFee)
+            revert WormholeBridgeMinAmountOutTooBig(minAmountOut, amountIn, relayerFee);
 
         uint256 preBalanceIn = IERC20(token).balanceOf(address(this));
 
@@ -116,7 +117,8 @@ contract WormholeConnector {
         );
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert WormholeBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert WormholeBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
+++ b/packages/connectors/contracts/bridge/wormhole/WormholeConnector.sol
@@ -27,7 +27,7 @@ import './IWormhole.sol';
  */
 contract WormholeConnector {
     /**
-     * @dev The chain ID is the same of the current chain
+     * @dev The source and destination chains are the same
      */
     error WormholeBridgeSameChain(uint256 chainId);
 
@@ -47,9 +47,9 @@ contract WormholeConnector {
     error WormholeBridgeMinAmountOutTooBig(uint256 minAmountOut, uint256 amountIn, uint256 relayerFee);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token balance is lower than the previous token balance minus the amount bridged
      */
-    error WormholeBridgeBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+    error WormholeBridgeBadPostTokenBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
 
     /**
      * @dev The chain ID is not supported
@@ -118,7 +118,7 @@ contract WormholeConnector {
 
         uint256 postBalanceIn = IERC20(token).balanceOf(address(this));
         if (postBalanceIn < preBalanceIn - amountIn)
-            revert WormholeBridgeBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+            revert WormholeBridgeBadPostTokenBalance(postBalanceIn, preBalanceIn, amountIn);
     }
 
     /**

--- a/packages/connectors/contracts/liquidity/convex/ConvexConnector.sol
+++ b/packages/connectors/contracts/liquidity/convex/ConvexConnector.sol
@@ -28,17 +28,17 @@ import './ICvxBooster.sol';
 contract ConvexConnector {
     using FixedPoint for uint256;
     /**
-     * @dev Failed to deposit tokens into Convex booster
+     * @dev Failed to deposit tokens into the Convex booster
      */
     error ConvexBoosterDepositFailed(uint256 poolId, uint256 amount);
 
     /**
-     * @dev Failed to withdraw tokens from Convex pool in the Convex booster
+     * @dev Failed to withdraw tokens from Convex pool
      */
     error ConvexCvxPoolWithdrawFailed(address cvxPool, uint256 amount);
 
     /**
-     * @dev Convex pool associated with the given Curve pool not found
+     * @dev Missing Convex pool for the requested Curve pool
      */
     error ConvexCvxPoolNotFound(address curvePool);
 

--- a/packages/connectors/contracts/liquidity/convex/ConvexConnector.sol
+++ b/packages/connectors/contracts/liquidity/convex/ConvexConnector.sol
@@ -27,6 +27,12 @@ import './ICvxBooster.sol';
  */
 contract ConvexConnector {
     using FixedPoint for uint256;
+
+    /**
+     * @dev Missing Convex pool for the requested Curve pool
+     */
+    error ConvexCvxPoolNotFound(address curvePool);
+
     /**
      * @dev Failed to deposit tokens into the Convex booster
      */
@@ -36,11 +42,6 @@ contract ConvexConnector {
      * @dev Failed to withdraw tokens from Convex pool
      */
     error ConvexCvxPoolWithdrawFailed(address cvxPool, uint256 amount);
-
-    /**
-     * @dev Missing Convex pool for the requested Curve pool
-     */
-    error ConvexCvxPoolNotFound(address curvePool);
 
     // Convex booster
     ICvxBooster public immutable booster;
@@ -98,6 +99,7 @@ contract ConvexConnector {
         uint256 initialCvxPoolTokenBalance = cvxPool.balanceOf(address(this));
         IERC20(curvePool).approve(address(booster), amount);
         if (!booster.deposit(poolId, amount)) revert ConvexBoosterDepositFailed(poolId, amount);
+
         uint256 finalCvxPoolTokenBalance = cvxPool.balanceOf(address(this));
         return finalCvxPoolTokenBalance - initialCvxPoolTokenBalance;
     }
@@ -111,9 +113,9 @@ contract ConvexConnector {
         if (amount == 0) return 0;
         address curvePool = getCurvePool(cvxPool);
 
-        // Unstake from Convex
         uint256 initialPoolTokenBalance = IERC20(curvePool).balanceOf(address(this));
         if (!ICvxPool(cvxPool).withdraw(amount, true)) revert ConvexCvxPoolWithdrawFailed(cvxPool, amount);
+
         uint256 finalPoolTokenBalance = IERC20(curvePool).balanceOf(address(this));
         return finalPoolTokenBalance - initialPoolTokenBalance;
     }

--- a/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
+++ b/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
@@ -26,6 +26,7 @@ import './I2CrvPool.sol';
  */
 contract Curve2CrvConnector {
     using FixedPoint for uint256;
+
     /**
      * @dev Failed to find the token in the 2CRV pool
      */

--- a/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
+++ b/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
@@ -26,6 +26,20 @@ import './I2CrvPool.sol';
  */
 contract Curve2CrvConnector {
     using FixedPoint for uint256;
+    /**
+     * @dev Failed to find the token in the 2CRV pool
+     */
+    error TokenNotFound(address pool, address token);
+
+    /**
+     * @dev Token decimals exceed 18
+     */
+    error TokenDecimalsAbove18(address token, uint256 decimals);
+
+    /**
+     * @dev The slippage is above one
+     */
+    error InvalidSlippage(uint256 slippage);
 
     /**
      * @dev Adds liquidity to the 2CRV pool
@@ -36,7 +50,7 @@ contract Curve2CrvConnector {
      */
     function join(address pool, address tokenIn, uint256 amountIn, uint256 slippage) external returns (uint256) {
         if (amountIn == 0) return 0;
-        require(slippage <= FixedPoint.ONE, '2CRV_SLIPPAGE_ABOVE_ONE');
+        if (slippage > FixedPoint.ONE) revert InvalidSlippage(slippage);
         (uint256 tokenIndex, uint256 tokenScale) = _findTokenInfo(pool, tokenIn);
 
         // Compute min amount out
@@ -65,7 +79,7 @@ contract Curve2CrvConnector {
         returns (uint256 amountOut)
     {
         if (amountIn == 0) return 0;
-        require(slippage <= FixedPoint.ONE, '2CRV_INVALID_SLIPPAGE');
+        if (slippage > FixedPoint.ONE) revert InvalidSlippage(slippage);
         (uint256 tokenIndex, uint256 tokenScale) = _findTokenInfo(pool, tokenOut);
 
         // Compute min amount out
@@ -87,13 +101,13 @@ contract Curve2CrvConnector {
             try I2CrvPool(pool).coins(i) returns (address coin) {
                 if (token == coin) {
                     uint256 decimals = IERC20Metadata(token).decimals();
-                    require(decimals <= 18, '2CRV_TOKEN_ABOVE_18_DECIMALS');
+                    if (decimals > 18) revert TokenDecimalsAbove18(token, decimals);
                     return (i, 10**(18 - decimals));
                 }
             } catch {
-                revert('2CRV_TOKEN_NOT_FOUND');
+                revert TokenNotFound(pool, token);
             }
         }
-        revert('2CRV_TOKEN_NOT_FOUND');
+        revert TokenNotFound(pool, token);
     }
 }

--- a/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
+++ b/packages/connectors/contracts/liquidity/curve/Curve2CrvConnector.sol
@@ -29,17 +29,17 @@ contract Curve2CrvConnector {
     /**
      * @dev Failed to find the token in the 2CRV pool
      */
-    error TokenNotFound(address pool, address token);
+    error Curve2CrvTokenNotFound(address pool, address token);
 
     /**
      * @dev Token decimals exceed 18
      */
-    error TokenDecimalsAbove18(address token, uint256 decimals);
+    error Curve2CrvTokenDecimalsAbove18(address token, uint256 decimals);
 
     /**
      * @dev The slippage is above one
      */
-    error InvalidSlippage(uint256 slippage);
+    error Curve2CrvSlippageAboveOne(uint256 slippage);
 
     /**
      * @dev Adds liquidity to the 2CRV pool
@@ -50,7 +50,7 @@ contract Curve2CrvConnector {
      */
     function join(address pool, address tokenIn, uint256 amountIn, uint256 slippage) external returns (uint256) {
         if (amountIn == 0) return 0;
-        if (slippage > FixedPoint.ONE) revert InvalidSlippage(slippage);
+        if (slippage > FixedPoint.ONE) revert Curve2CrvSlippageAboveOne(slippage);
         (uint256 tokenIndex, uint256 tokenScale) = _findTokenInfo(pool, tokenIn);
 
         // Compute min amount out
@@ -79,7 +79,7 @@ contract Curve2CrvConnector {
         returns (uint256 amountOut)
     {
         if (amountIn == 0) return 0;
-        if (slippage > FixedPoint.ONE) revert InvalidSlippage(slippage);
+        if (slippage > FixedPoint.ONE) revert Curve2CrvSlippageAboveOne(slippage);
         (uint256 tokenIndex, uint256 tokenScale) = _findTokenInfo(pool, tokenOut);
 
         // Compute min amount out
@@ -101,13 +101,13 @@ contract Curve2CrvConnector {
             try I2CrvPool(pool).coins(i) returns (address coin) {
                 if (token == coin) {
                     uint256 decimals = IERC20Metadata(token).decimals();
-                    if (decimals > 18) revert TokenDecimalsAbove18(token, decimals);
+                    if (decimals > 18) revert Curve2CrvTokenDecimalsAbove18(token, decimals);
                     return (i, 10**(18 - decimals));
                 }
             } catch {
-                revert TokenNotFound(pool, token);
+                revert Curve2CrvTokenNotFound(pool, token);
             }
         }
-        revert TokenNotFound(pool, token);
+        revert Curve2CrvTokenNotFound(pool, token);
     }
 }

--- a/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
+++ b/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
@@ -27,23 +27,23 @@ import './IOneInchV5AggregationRouter.sol';
  * @dev Interfaces with 1inch V5 to swap tokens
  */
 contract OneInchV5Connector {
-    // Reference to 1inch aggregation router v5
-    IOneInchV5AggregationRouter public immutable oneInchV5Router;
-
     /**
      * @dev The token in is the same as the token out
      */
     error OneInchV5SwapSameToken(address token);
 
     /**
-     * @dev The post token in balance is lower than the previous token in balance minus the amount in
-     */
-    error OneInchV5BadPostTokenInBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
-
-    /**
-     * @dev The amount out is less than the minimum amount out
+     * @dev The amount out is lower than the minimum amount out
      */
     error OneInchV5BadAmountOut(uint256 amountOut, uint256 minAmountOut);
+
+    /**
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
+     */
+    error OneInchV5BadPostTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    // Reference to 1inch aggregation router v5
+    IOneInchV5AggregationRouter public immutable oneInchV5Router;
 
     /**
      * @dev Creates a new OneInchV5Connector contract
@@ -74,8 +74,8 @@ contract OneInchV5Connector {
         Address.functionCall(address(oneInchV5Router), data, '1INCH_V5_SWAP_FAILED');
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn)
-            revert OneInchV5BadPostTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        bool isPostBalanceInUnexpected = postBalanceIn < preBalanceIn - amountIn;
+        if (isPostBalanceInUnexpected) revert OneInchV5BadPostTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
+++ b/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
@@ -36,9 +36,9 @@ contract OneInchV5Connector {
     error OneInchV5SwapSameToken(address token);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
      */
-    error OneInchV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+    error OneInchV5BadPostTokenInBalance(uint256 postBalance, uint256 preBalance, uint256 amount);
 
     /**
      * @dev The amount out is less than the minimum amount out
@@ -75,7 +75,7 @@ contract OneInchV5Connector {
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
         if (postBalanceIn < preBalanceIn - amountIn)
-            revert OneInchV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+            revert OneInchV5BadPostTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
+++ b/packages/connectors/contracts/swap/1inch-v5/OneInchV5Connector.sol
@@ -41,7 +41,7 @@ contract OneInchV5Connector {
     error OneInchV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
-     * @dev The amount out is less than the minimum amount out 
+     * @dev The amount out is less than the minimum amount out
      */
     error OneInchV5BadAmountOut(uint256 amountOut, uint256 minAmountOut);
 
@@ -74,7 +74,8 @@ contract OneInchV5Connector {
         Address.functionCall(address(oneInchV5Router), data, '1INCH_V5_SWAP_FAILED');
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert OneInchV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert OneInchV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
+++ b/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
@@ -36,7 +36,7 @@ contract HopSwapConnector {
     error HopDexAddressZero();
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token in balance is lower than the pre token in balance minus the amount in
      */
     error HopBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 

--- a/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
+++ b/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
@@ -41,7 +41,7 @@ contract HopSwapConnector {
     error HopBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
-     * @dev The amount out is less than the minimum amount out 
+     * @dev The amount out is less than the minimum amount out
      */
     error HopBadAmountOut(uint256 amountOut, uint256 minAmountOut);
 

--- a/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
+++ b/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
@@ -26,6 +26,26 @@ import './IHopDex.sol';
  */
 contract HopSwapConnector {
     /**
+     * @dev The token in is the same as the token out
+     */
+    error HopSwapSameToken(address token);
+
+    /**
+     * @dev The dex address is zero
+     */
+    error HopDexAddressZero();
+
+    /**
+     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     */
+    error HopBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    /**
+     * @dev The amount out is less than the minimum amount out 
+     */
+    error HopBadAmountOut(uint256 amountOut, uint256 minAmountOut);
+
+    /**
      * @dev Executes a token swap in Hop
      * @param tokenIn Token being sent
      * @param tokenOut Token being received
@@ -37,8 +57,8 @@ contract HopSwapConnector {
         external
         returns (uint256 amountOut)
     {
-        require(tokenIn != tokenOut, 'HOP_SWAP_SAME_TOKEN');
-        require(hopDexAddress != address(0), 'HOP_DEX_ADDRESS_ZERO');
+        if (tokenIn == tokenOut) revert HopSwapSameToken(tokenIn);
+        if (hopDexAddress == address(0)) revert HopDexAddressZero();
 
         uint256 preBalanceIn = IERC20(tokenIn).balanceOf(address(this));
         uint256 preBalanceOut = IERC20(tokenOut).balanceOf(address(this));
@@ -51,10 +71,10 @@ contract HopSwapConnector {
         hopDex.swap(tokenInIndex, tokenOutIndex, amountIn, minAmountOut, block.timestamp);
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        require(postBalanceIn >= preBalanceIn - amountIn, 'HOP_BAD_TOKEN_IN_BALANCE');
+        if (postBalanceIn < preBalanceIn - amountIn) revert HopBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;
-        require(amountOut >= minAmountOut, 'HOP_MIN_AMOUNT_OUT');
+        if (amountOut < minAmountOut) revert HopBadAmountOut(amountOut, minAmountOut);
     }
 }

--- a/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
+++ b/packages/connectors/contracts/swap/hop/HopSwapConnector.sol
@@ -36,14 +36,14 @@ contract HopSwapConnector {
     error HopDexAddressZero();
 
     /**
-     * @dev The post token in balance is lower than the pre token in balance minus the amount in
-     */
-    error HopBadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
-
-    /**
-     * @dev The amount out is less than the minimum amount out
+     * @dev The amount out is lower than the minimum amount out
      */
     error HopBadAmountOut(uint256 amountOut, uint256 minAmountOut);
+
+    /**
+     * @dev The post token in balance is lower than the pre token in balance minus the amount in
+     */
+    error HopBadPostTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
      * @dev Executes a token swap in Hop
@@ -71,7 +71,8 @@ contract HopSwapConnector {
         hopDex.swap(tokenInIndex, tokenOutIndex, amountIn, minAmountOut, block.timestamp);
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert HopBadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        bool isPostBalanceInUnexpected = postBalanceIn < preBalanceIn - amountIn;
+        if (isPostBalanceInUnexpected) revert HopBadPostTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
+++ b/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
@@ -32,7 +32,7 @@ contract ParaswapV5Connector {
     error ParaswapV5SwapSameToken(address token);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
      */
     error ParaswapV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 

--- a/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
+++ b/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
@@ -37,7 +37,7 @@ contract ParaswapV5Connector {
     error ParaswapV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
-     * @dev The amount out is less than the minimum amount out 
+     * @dev The amount out is less than the minimum amount out
      */
     error ParaswapV5BadAmountOut(uint256 amountOut, uint256 minAmountOut);
 
@@ -74,7 +74,8 @@ contract ParaswapV5Connector {
         Address.functionCall(address(paraswapV5Augustus), data, 'PARASWAP_V5_SWAP_FAILED');
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert ParaswapV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert ParaswapV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
+++ b/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
@@ -26,6 +26,21 @@ import './IParaswapV5Augustus.sol';
  * @dev Interfaces with Paraswap V5 to swap tokens
  */
 contract ParaswapV5Connector {
+    /**
+     * @dev The token in is the same as the token out
+     */
+    error ParaswapV5SwapSameToken(address token);
+
+    /**
+     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     */
+    error ParaswapV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
+
+    /**
+     * @dev The amount out is less than the minimum amount out 
+     */
+    error ParaswapV5BadAmountOut(uint256 amountOut, uint256 minAmountOut);
+
     // Reference to Paraswap V5 Augustus swapper
     IParaswapV5Augustus public immutable paraswapV5Augustus;
 
@@ -49,7 +64,7 @@ contract ParaswapV5Connector {
         external
         returns (uint256 amountOut)
     {
-        require(tokenIn != tokenOut, 'PARASWAP_V5_SWAP_SAME_TOKEN');
+        if (tokenIn == tokenOut) revert ParaswapV5SwapSameToken(tokenIn);
 
         uint256 preBalanceIn = IERC20(tokenIn).balanceOf(address(this));
         uint256 preBalanceOut = IERC20(tokenOut).balanceOf(address(this));
@@ -59,10 +74,10 @@ contract ParaswapV5Connector {
         Address.functionCall(address(paraswapV5Augustus), data, 'PARASWAP_V5_SWAP_FAILED');
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        require(postBalanceIn >= preBalanceIn - amountIn, 'PARASWAP_V5_BAD_TOKEN_IN_BALANCE');
+        if (postBalanceIn < preBalanceIn - amountIn) revert ParaswapV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;
-        require(amountOut >= minAmountOut, 'PARASWAP_V5_MIN_AMOUNT_OUT');
+        if (amountOut < minAmountOut) revert ParaswapV5BadAmountOut(amountOut, minAmountOut);
     }
 }

--- a/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
+++ b/packages/connectors/contracts/swap/paraswap-v5/ParaswapV5Connector.sol
@@ -32,14 +32,14 @@ contract ParaswapV5Connector {
     error ParaswapV5SwapSameToken(address token);
 
     /**
-     * @dev The post token in balance is lower than the previous token in balance minus the amount in
-     */
-    error ParaswapV5BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
-
-    /**
-     * @dev The amount out is less than the minimum amount out
+     * @dev The amount out is lower than the minimum amount out
      */
     error ParaswapV5BadAmountOut(uint256 amountOut, uint256 minAmountOut);
+
+    /**
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
+     */
+    error ParaswapV5BadPostTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     // Reference to Paraswap V5 Augustus swapper
     IParaswapV5Augustus public immutable paraswapV5Augustus;
@@ -74,8 +74,8 @@ contract ParaswapV5Connector {
         Address.functionCall(address(paraswapV5Augustus), data, 'PARASWAP_V5_SWAP_FAILED');
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn)
-            revert ParaswapV5BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        bool isPostBalanceInUnexpected = postBalanceIn < preBalanceIn - amountIn;
+        if (isPostBalanceInUnexpected) revert ParaswapV5BadPostTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/uniswap-v2/UniswapV2Connector.sol
+++ b/packages/connectors/contracts/swap/uniswap-v2/UniswapV2Connector.sol
@@ -39,7 +39,7 @@ contract UniswapV2Connector {
     error UniswapV2BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
-     * @dev The amount out is less than the minimum amount out 
+     * @dev The amount out is less than the minimum amount out
      */
     error UniswapV2BadAmountOut(uint256 amountOut, uint256 minAmountOut);
 
@@ -85,7 +85,8 @@ contract UniswapV2Connector {
             : _batchSwap(tokenIn, tokenOut, amountIn, minAmountOut, hopTokens);
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert UniswapV2BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert UniswapV2BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/uniswap-v2/UniswapV2Connector.sol
+++ b/packages/connectors/contracts/swap/uniswap-v2/UniswapV2Connector.sol
@@ -34,7 +34,7 @@ contract UniswapV2Connector {
     error UniswapV2SwapSameToken(address token);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
      */
     error UniswapV2BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 

--- a/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
+++ b/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
@@ -99,7 +99,8 @@ contract UniswapV3Connector {
             : _batchSwap(tokenIn, tokenOut, amountIn, minAmountOut, fee, hopTokens, hopFees);
 
         uint256 postBalanceIn = IERC20(tokenIn).balanceOf(address(this));
-        if (postBalanceIn < preBalanceIn - amountIn) revert UniswapV3BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
+        if (postBalanceIn < preBalanceIn - amountIn)
+            revert UniswapV3BadTokenInBalance(postBalanceIn, preBalanceIn, amountIn);
 
         uint256 postBalanceOut = IERC20(tokenOut).balanceOf(address(this));
         amountOut = postBalanceOut - preBalanceOut;

--- a/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
+++ b/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
@@ -42,7 +42,7 @@ contract UniswapV3Connector {
     error UniswapV3BadHopTokensFeesLength(uint256 hopTokensLength, uint256 hopFeesLength);
 
     /**
-     * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
+     * @dev The post token in balance is lower than the previous token in balance minus the amount in
      */
     error UniswapV3BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 

--- a/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
+++ b/packages/connectors/contracts/swap/uniswap-v3/UniswapV3Connector.sol
@@ -37,12 +37,17 @@ contract UniswapV3Connector {
     error UniswapV3SwapSameToken(address token);
 
     /**
+     * @dev The hop-tokens and hop-fees arrays have different lengths
+     */
+    error UniswapV3BadHopTokensFeesLength(uint256 hopTokensLength, uint256 hopFeesLength);
+
+    /**
      * @dev The token balance after the bridge is less than the token balance before the bridge minus the amount bridged
      */
     error UniswapV3BadTokenInBalance(uint256 postBalanceIn, uint256 preBalanceIn, uint256 amountIn);
 
     /**
-     * @dev The amount out is less than the minimum amount out 
+     * @dev The amount out is less than the minimum amount out
      */
     error UniswapV3BadAmountOut(uint256 amountOut, uint256 minAmountOut);
 
@@ -82,7 +87,8 @@ contract UniswapV3Connector {
         uint24[] memory hopFees
     ) external returns (uint256 amountOut) {
         if (tokenIn == tokenOut) revert UniswapV3SwapSameToken(tokenIn);
-        if (hopTokens.length != hopFees.length) revert UniswapV3BadHopTokensFeesLength(hopTokens.length, hopFees.length);
+        if (hopTokens.length != hopFees.length)
+            revert UniswapV3BadHopTokensFeesLength(hopTokens.length, hopFees.length);
 
         uint256 preBalanceIn = IERC20(tokenIn).balanceOf(address(this));
         uint256 preBalanceOut = IERC20(tokenOut).balanceOf(address(this));

--- a/packages/connectors/test/bridge/axelar/AxelarConnector.behavior.ts
+++ b/packages/connectors/test/bridge/axelar/AxelarConnector.behavior.ts
@@ -47,7 +47,7 @@ export function itBehavesLikeAxelarConnector(
         it('reverts', async function () {
           await expect(
             this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, whale.address)
-          ).to.be.revertedWith('AXELAR_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('AxelarBridgeSameChain').withArgs(destinationChainId)
         })
       }
     }
@@ -94,7 +94,7 @@ export function itBehavesLikeAxelarConnector(
       it('reverts', async function () {
         await expect(
           this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, whale.address)
-        ).to.be.revertedWith('AXELAR_UNKNOWN_CHAIN_ID')
+        ).to.be.revertedWith('AxelarBridgeUnknownChainId').withArgs(destinationChainId)
       })
     })
   })
@@ -102,7 +102,7 @@ export function itBehavesLikeAxelarConnector(
   context('when the recipient is the zero address', async () => {
     it('reverts', async function () {
       await expect(this.connector.connect(whale).execute(0, tokenAddress, 0, ZERO_ADDRESS)).to.be.revertedWith(
-        'AXELAR_BRIDGE_RECIPIENT_ZERO'
+        'AxelarBridgeRecipientZero'
       )
     })
   })

--- a/packages/connectors/test/bridge/axelar/AxelarConnector.behavior.ts
+++ b/packages/connectors/test/bridge/axelar/AxelarConnector.behavior.ts
@@ -3,6 +3,8 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { expect } from 'chai'
 import { BigNumber, Contract } from 'ethers'
 
+/* eslint-disable no-secrets/no-secrets */
+
 export function itBehavesLikeAxelarConnector(
   sourceChainId: number,
   tokenAddress: string,
@@ -47,7 +49,7 @@ export function itBehavesLikeAxelarConnector(
         it('reverts', async function () {
           await expect(
             this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, whale.address)
-          ).to.be.revertedWith('AxelarBridgeSameChain').withArgs(destinationChainId)
+          ).to.be.revertedWith('AxelarBridgeSameChain')
         })
       }
     }
@@ -94,7 +96,7 @@ export function itBehavesLikeAxelarConnector(
       it('reverts', async function () {
         await expect(
           this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, whale.address)
-        ).to.be.revertedWith('AxelarBridgeUnknownChainId').withArgs(destinationChainId)
+        ).to.be.revertedWith('AxelarBridgeUnknownChainId')
       })
     })
   })

--- a/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
+++ b/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
@@ -59,7 +59,7 @@ export function itBehavesLikeConnextConnector(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-            ).to.be.revertedWith('ConnextBridgeRelayerFeeGTAmount').withArgs(relayerFee, amountIn)
+            ).to.be.revertedWith('ConnextBridgeRelayerFeeGTAmount')
           })
         })
 

--- a/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
+++ b/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
@@ -3,6 +3,8 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { expect } from 'chai'
 import { BigNumber, Contract } from 'ethers'
 
+/* eslint-disable no-secrets/no-secrets */
+
 export function itBehavesLikeConnextConnector(
   sourceChainId: number,
   tokenAddress: string,
@@ -71,7 +73,7 @@ export function itBehavesLikeConnextConnector(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-            ).to.be.revertedWith('ConnextBridgeMinAmountOutTooBig').withArgs(minAmountOut, amountIn, relayerFee)
+            ).to.be.revertedWith('ConnextBridgeMinAmountOutTooBig')
           })
         })
       } else {
@@ -80,7 +82,7 @@ export function itBehavesLikeConnextConnector(
             this.connector
               .connect(whale)
               .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-          ).to.be.revertedWith('ConnextBridgeSameChain').withArgs(destinationChainId)
+          ).to.be.revertedWith('ConnextBridgeSameChain')
         })
       }
     }
@@ -129,7 +131,7 @@ export function itBehavesLikeConnextConnector(
           this.connector
             .connect(whale)
             .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-        ).to.be.revertedWith('ConnextBridgeUnknownChainId').withArgs(destinationChainId)
+        ).to.be.revertedWith('ConnextBridgeUnknownChainId')
       })
     })
   })

--- a/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
+++ b/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
@@ -52,22 +52,26 @@ export function itBehavesLikeConnextConnector(
         })
 
         context('when relayerFee is greater than amountIn', () => {
+          const relayerFee = amountIn.add(1)
+
           it('reverts', async function () {
             await expect(
               this.connector
                 .connect(whale)
-                .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, amountIn.add(1))
-            ).to.be.revertedWith('CONNEXT_RELAYER_FEE_GT_AMOUNT_IN')
+                .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
+            ).to.be.revertedWith('ConnextBridgeRelayerFeeGTAmount').withArgs(relayerFee, amountIn)
           })
         })
 
         context('when minAmountOut is greater than amountIn minus relayerFee', () => {
+          const minAmountOut = amountIn.add(1)
+
           it('reverts', async function () {
             await expect(
               this.connector
                 .connect(whale)
-                .execute(destinationChainId, tokenAddress, amountIn, amountIn.add(1), whale.address, relayerFee)
-            ).to.be.revertedWith('CONNEXT_MIN_AMOUNT_OUT_TOO_BIG')
+                .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
+            ).to.be.revertedWith('ConnextBridgeMinAmountOutTooBig').withArgs(minAmountOut, amountIn, relayerFee)
           })
         })
       } else {
@@ -76,7 +80,7 @@ export function itBehavesLikeConnextConnector(
             this.connector
               .connect(whale)
               .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-          ).to.be.revertedWith('CONNEXT_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('ConnextBridgeSameChain').withArgs(destinationChainId)
         })
       }
     }
@@ -125,7 +129,7 @@ export function itBehavesLikeConnextConnector(
           this.connector
             .connect(whale)
             .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-        ).to.be.revertedWith('CONNEXT_UNKNOWN_CHAIN_ID')
+        ).to.be.revertedWith('ConnextBridgeUnknownChainId').withArgs(destinationChainId)
       })
     })
   })
@@ -133,7 +137,7 @@ export function itBehavesLikeConnextConnector(
   context('when the recipient is the zero address', async () => {
     it('reverts', async function () {
       await expect(this.connector.connect(whale).execute(0, tokenAddress, 0, 0, ZERO_ADDRESS, 0)).to.be.revertedWith(
-        'CONNEXT_BRIDGE_RECIPIENT_ZERO'
+        'ConnextBridgeRecipientZero'
       )
     })
   })

--- a/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
+++ b/packages/connectors/test/bridge/connext/ConnextConnector.behavior.ts
@@ -61,7 +61,7 @@ export function itBehavesLikeConnextConnector(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address, relayerFee)
-            ).to.be.revertedWith('ConnextBridgeRelayerFeeGTAmount')
+            ).to.be.revertedWith('ConnextBridgeRelayerFeeGtAmount')
           })
         })
 

--- a/packages/connectors/test/bridge/hop/HopConnector.mainnet.ts
+++ b/packages/connectors/test/bridge/hop/HopConnector.mainnet.ts
@@ -86,7 +86,7 @@ describe('HopConnector', () => {
                   ZERO_ADDRESS,
                   0
                 )
-            ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+            ).to.be.revertedWith('HopBridgeSameChain')
           })
         }
       }
@@ -123,7 +123,7 @@ describe('HopConnector', () => {
             connector
               .connect(whale)
               .execute(destinationChainId, WETH, 0, 0, whale.address, HOP_ETH_BRIDGE, 0, ZERO_ADDRESS, 0)
-          ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('HopBridgeSameChain')
         })
       })
 
@@ -135,7 +135,7 @@ describe('HopConnector', () => {
             connector
               .connect(whale)
               .execute(destinationChainId, WETH, 0, 0, whale.address, HOP_ETH_BRIDGE, 0, ZERO_ADDRESS, 0)
-          ).to.be.revertedWith('HOP_BRIDGE_OP_NOT_SUPPORTED')
+          ).to.be.revertedWith('HopBridgeOpNotSupported')
         })
       })
     })
@@ -144,7 +144,7 @@ describe('HopConnector', () => {
       it('reverts', async function () {
         await expect(
           connector.connect(whale).execute(0, WETH, 0, 0, ZERO_ADDRESS, ZERO_ADDRESS, 0, ZERO_ADDRESS, 0)
-        ).to.be.revertedWith('HOP_BRIDGE_RECIPIENT_ZERO')
+        ).to.be.revertedWith('HopBridgeRecipientZero')
       })
     })
   })
@@ -207,7 +207,7 @@ describe('HopConnector', () => {
                   ZERO_ADDRESS,
                   0
                 )
-            ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+            ).to.be.revertedWith('HopBridgeSameChain')
           })
         }
       }
@@ -242,7 +242,7 @@ describe('HopConnector', () => {
         it('reverts', async () => {
           await expect(
             connector.execute(destinationChainId, USDC, 0, 0, whale.address, HOP_USDC_BRIDGE, 0, ZERO_ADDRESS, 0)
-          ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('HopBridgeSameChain')
         })
       })
 
@@ -252,7 +252,7 @@ describe('HopConnector', () => {
         it('reverts', async () => {
           await expect(
             connector.execute(destinationChainId, USDC, 0, 0, whale.address, HOP_USDC_BRIDGE, 0, ZERO_ADDRESS, 0)
-          ).to.be.revertedWith('HOP_BRIDGE_OP_NOT_SUPPORTED')
+          ).to.be.revertedWith('HopBridgeOpNotSupported')
         })
       })
     })
@@ -261,7 +261,7 @@ describe('HopConnector', () => {
       it('reverts', async function () {
         await expect(
           connector.connect(whale).execute(0, USDC, 0, 0, ZERO_ADDRESS, HOP_USDC_BRIDGE, 0, ZERO_ADDRESS, 0)
-        ).to.be.revertedWith('HOP_BRIDGE_RECIPIENT_ZERO')
+        ).to.be.revertedWith('HopBridgeRecipientZero')
       })
     })
   })

--- a/packages/connectors/test/bridge/hop/HopL2ERC20Connector.behavior.ts
+++ b/packages/connectors/test/bridge/hop/HopL2ERC20Connector.behavior.ts
@@ -135,7 +135,7 @@ export function itBehavesLikeHopERC20Connector(
                 ZERO_ADDRESS,
                 bonderFee
               )
-          ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('HopBridgeSameChain').withArgs(destinationChainId)
         })
       }
     }
@@ -187,7 +187,7 @@ export function itBehavesLikeHopERC20Connector(
     it('reverts', async function () {
       await expect(
         this.connector.connect(whale).execute(0, tokenAddress, 0, 0, ZERO_ADDRESS, ZERO_ADDRESS, 0, ZERO_ADDRESS, 0)
-      ).to.be.revertedWith('HOP_BRIDGE_RECIPIENT_ZERO')
+      ).to.be.revertedWith('HopBridgeRecipientZero')
     })
   })
 }

--- a/packages/connectors/test/bridge/hop/HopL2ERC20Connector.behavior.ts
+++ b/packages/connectors/test/bridge/hop/HopL2ERC20Connector.behavior.ts
@@ -135,7 +135,7 @@ export function itBehavesLikeHopERC20Connector(
                 ZERO_ADDRESS,
                 bonderFee
               )
-          ).to.be.revertedWith('HopBridgeSameChain').withArgs(destinationChainId)
+          ).to.be.revertedWith('HopBridgeSameChain')
         })
       }
     }

--- a/packages/connectors/test/bridge/hop/HopL2NativeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/hop/HopL2NativeConnector.behavior.ts
@@ -137,7 +137,7 @@ export function itBehavesLikeHopNativeConnector(
                   ZERO_ADDRESS,
                   0
                 )
-            ).to.be.revertedWith('HOP_BRIDGE_SAME_CHAIN')
+            ).to.be.revertedWith('HopBridgeSameChain').withArgs(destinationChainId)
           })
         }
       }
@@ -202,7 +202,7 @@ export function itBehavesLikeHopNativeConnector(
         this.connector
           .connect(whale)
           .execute(0, wrappedNativeTokenAddress, 0, 0, ZERO_ADDRESS, ZERO_ADDRESS, 0, ZERO_ADDRESS, 0)
-      ).to.be.revertedWith('HOP_BRIDGE_RECIPIENT_ZERO')
+      ).to.be.revertedWith('HopBridgeRecipientZero')
     })
   })
 }

--- a/packages/connectors/test/bridge/hop/HopL2NativeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/hop/HopL2NativeConnector.behavior.ts
@@ -137,7 +137,7 @@ export function itBehavesLikeHopNativeConnector(
                   ZERO_ADDRESS,
                   0
                 )
-            ).to.be.revertedWith('HopBridgeSameChain').withArgs(destinationChainId)
+            ).to.be.revertedWith('HopBridgeSameChain')
           })
         }
       }

--- a/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
@@ -52,12 +52,13 @@ export function itBehavesLikeWormholeConnector(
 
         context('when relayerFee is greater than amountIn', () => {
           const amountIn = relayerFee.sub(1)
+
           it('reverts', async function () {
             await expect(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-            ).to.be.revertedWith('WormholeBridgeRelayerFeeGTAmount').withArgs(relayerFee, amountIn)
+            ).to.be.revertedWith('WormholeBridgeRelayerFeeGTAmount')
           })
         })
 

--- a/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
@@ -60,7 +60,7 @@ export function itBehavesLikeWormholeConnector(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-            ).to.be.revertedWith('WormholeBridgeRelayerFeeGTAmount')
+            ).to.be.revertedWith('WormholeBridgeRelayerFeeGtAmount')
           })
         })
 

--- a/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
@@ -3,6 +3,8 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { expect } from 'chai'
 import { BigNumber, Contract } from 'ethers'
 
+/* eslint-disable no-secrets/no-secrets */
+
 export function itBehavesLikeWormholeConnector(
   sourceChainId: number,
   tokenAddress: string,
@@ -69,7 +71,7 @@ export function itBehavesLikeWormholeConnector(
               this.connector
                 .connect(whale)
                 .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-            ).to.be.revertedWith('WormholeBridgeMinAmountOutTooBig').withArgs(minAmountOut, amountIn, relayerFee)
+            ).to.be.revertedWith('WormholeBridgeMinAmountOutTooBig')
           })
         })
       } else {
@@ -78,7 +80,7 @@ export function itBehavesLikeWormholeConnector(
             this.connector
               .connect(whale)
               .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-          ).to.be.revertedWith('WormholeBridgeSameChain').withArgs(destinationChainId)
+          ).to.be.revertedWith('WormholeBridgeSameChain')
         })
       }
     }
@@ -101,7 +103,7 @@ export function itBehavesLikeWormholeConnector(
       it('reverts', async function () {
         await expect(
           this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-        ).to.be.revertedWith('WormholeBridgeUnknownChainId').withArgs(destinationChainId)
+        ).to.be.revertedWith('WormholeBridgeUnknownChainId')
       })
     })
   })

--- a/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
@@ -66,6 +66,7 @@ export function itBehavesLikeWormholeConnector(
 
         context('when minAmountOut is greater than amountIn minus relayerFee', () => {
           const minAmountOut = amountIn.add(1)
+
           it('reverts', async function () {
             await expect(
               this.connector

--- a/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
+++ b/packages/connectors/test/bridge/wormhole/WormholeConnector.behavior.ts
@@ -51,22 +51,24 @@ export function itBehavesLikeWormholeConnector(
         })
 
         context('when relayerFee is greater than amountIn', () => {
+          const amountIn = relayerFee.sub(1)
           it('reverts', async function () {
             await expect(
               this.connector
                 .connect(whale)
-                .execute(destinationChainId, tokenAddress, relayerFee.sub(1), minAmountOut, whale.address)
-            ).to.be.revertedWith('WORMHOLE_RELAYER_FEE_GT_AMT_IN')
+                .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
+            ).to.be.revertedWith('WormholeBridgeRelayerFeeGTAmount').withArgs(relayerFee, amountIn)
           })
         })
 
         context('when minAmountOut is greater than amountIn minus relayerFee', () => {
+          const minAmountOut = amountIn.add(1)
           it('reverts', async function () {
             await expect(
               this.connector
                 .connect(whale)
-                .execute(destinationChainId, tokenAddress, amountIn, amountIn.add(1), whale.address)
-            ).to.be.revertedWith('WORMHOLE_MIN_AMOUNT_OUT_TOO_BIG')
+                .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
+            ).to.be.revertedWith('WormholeBridgeMinAmountOutTooBig').withArgs(minAmountOut, amountIn, relayerFee)
           })
         })
       } else {
@@ -75,7 +77,7 @@ export function itBehavesLikeWormholeConnector(
             this.connector
               .connect(whale)
               .execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-          ).to.be.revertedWith('WORMHOLE_BRIDGE_SAME_CHAIN')
+          ).to.be.revertedWith('WormholeBridgeSameChain').withArgs(destinationChainId)
         })
       }
     }
@@ -98,7 +100,7 @@ export function itBehavesLikeWormholeConnector(
       it('reverts', async function () {
         await expect(
           this.connector.connect(whale).execute(destinationChainId, tokenAddress, amountIn, minAmountOut, whale.address)
-        ).to.be.revertedWith('WORMHOLE_UNKNOWN_CHAIN_ID')
+        ).to.be.revertedWith('WormholeBridgeUnknownChainId').withArgs(destinationChainId)
       })
     })
   })
@@ -106,7 +108,7 @@ export function itBehavesLikeWormholeConnector(
   context('when the recipient is the zero address', async () => {
     it('reverts', async function () {
       await expect(this.connector.connect(whale).execute(0, tokenAddress, 0, 0, ZERO_ADDRESS)).to.be.revertedWith(
-        'WORMHOLE_BRIDGE_RECIPIENT_ZERO'
+        'WormholeBridgeRecipientZero'
       )
     })
   })

--- a/packages/deployer/contracts/Deployer.sol
+++ b/packages/deployer/contracts/Deployer.sol
@@ -44,7 +44,7 @@ contract Deployer {
      * @dev The namespace is empty
      */
     error DeployerNamespaceEmpty();
-    
+
     /**
      * @dev The name is empty
      */

--- a/packages/deployer/contracts/Deployer.sol
+++ b/packages/deployer/contracts/Deployer.sol
@@ -28,17 +28,17 @@ contract Deployer {
     /**
      * @dev The implementation is not registered
      */
-    error DeployerImplNotRegistered(address implementation);
+    error DeployerImplementationNotRegistered(address implementation);
 
     /**
      * @dev The implementation is stateless
      */
-    error DeployerImplStateless(address implementation);
+    error DeployerImplementationStateless(address implementation);
 
     /**
      * @dev The implementation is deprecated
      */
-    error DeployerImplDeprecated(address implementation);
+    error DeployerImplementationDeprecated(address implementation);
 
     /**
      * @dev The namespace is empty
@@ -190,9 +190,9 @@ contract Deployer {
      * @param implementation Address of the implementation to be checked
      */
     function _validateImplementation(address implementation) internal view {
-        if (!registry.isRegistered(implementation)) revert DeployerImplNotRegistered(implementation);
-        if (registry.isStateless(implementation)) revert DeployerImplStateless(implementation);
-        if (registry.isDeprecated(implementation)) revert DeployerImplDeprecated(implementation);
+        if (!registry.isRegistered(implementation)) revert DeployerImplementationNotRegistered(implementation);
+        if (registry.isStateless(implementation)) revert DeployerImplementationStateless(implementation);
+        if (registry.isDeprecated(implementation)) revert DeployerImplementationDeprecated(implementation);
     }
 
     /**

--- a/packages/deployer/contracts/Deployer.sol
+++ b/packages/deployer/contracts/Deployer.sol
@@ -25,8 +25,30 @@ import '@mimic-fi/v3-registry/contracts/interfaces/IRegistry.sol';
 contract Deployer {
     using Address for address;
 
-    // Registry reference
-    IRegistry public immutable registry;
+    /**
+     * @dev The implementation is not registered
+     */
+    error DeployerImplNotRegistered(address implementation);
+
+    /**
+     * @dev The implementation is stateless
+     */
+    error DeployerImplStateless(address implementation);
+
+    /**
+     * @dev The implementation is deprecated
+     */
+    error DeployerImplDeprecated(address implementation);
+
+    /**
+     * @dev The namespace is empty
+     */
+    error DeployerNamespaceEmpty();
+    
+    /**
+     * @dev The name is empty
+     */
+    error DeployerNameEmpty();
 
     /**
      * @dev Emitted every time an authorizer is deployed
@@ -38,7 +60,7 @@ contract Deployer {
      */
     event PriceOracleDeployed(string namespace, string name, address instance, address implementation);
 
-    /**Bas
+    /**
      * @dev Emitted every time a smart vault is deployed
      */
     event SmartVaultDeployed(string namespace, string name, address instance, address implementation);
@@ -47,6 +69,9 @@ contract Deployer {
      * @dev Emitted every time a task is deployed
      */
     event TaskDeployed(string namespace, string name, address instance, address implementation);
+
+    // Registry reference
+    IRegistry public immutable registry;
 
     /**
      * @dev Creates a new Deployer contract
@@ -165,9 +190,9 @@ contract Deployer {
      * @param implementation Address of the implementation to be checked
      */
     function _validateImplementation(address implementation) internal view {
-        require(registry.isRegistered(implementation), 'DEPLOYER_IMPL_NOT_REGISTERED');
-        require(!registry.isStateless(implementation), 'DEPLOYER_IMPL_STATELESS');
-        require(!registry.isDeprecated(implementation), 'DEPLOYER_IMPL_DEPRECATED');
+        if (!registry.isRegistered(implementation)) revert DeployerImplNotRegistered(implementation);
+        if (registry.isStateless(implementation)) revert DeployerImplStateless(implementation);
+        if (registry.isDeprecated(implementation)) revert DeployerImplDeprecated(implementation);
     }
 
     /**
@@ -177,8 +202,8 @@ contract Deployer {
         internal
         returns (address)
     {
-        require(bytes(namespace).length > 0, 'DEPLOYER_NAMESPACE_EMPTY');
-        require(bytes(name).length > 0, 'DEPLOYER_NAME_EMPTY');
+        if (bytes(namespace).length == 0) revert DeployerNamespaceEmpty();
+        if (bytes(name).length == 0) revert DeployerNameEmpty();
 
         bytes memory bytecode = abi.encodePacked(
             hex'3d602d80600a3d3981f3363d3d373d3d3d363d73',

--- a/packages/deployer/contracts/Deployer.sol
+++ b/packages/deployer/contracts/Deployer.sol
@@ -26,6 +26,16 @@ contract Deployer {
     using Address for address;
 
     /**
+     * @dev The namespace is empty
+     */
+    error DeployerNamespaceEmpty();
+
+    /**
+     * @dev The name is empty
+     */
+    error DeployerNameEmpty();
+
+    /**
      * @dev The implementation is not registered
      */
     error DeployerImplementationNotRegistered(address implementation);
@@ -39,16 +49,6 @@ contract Deployer {
      * @dev The implementation is deprecated
      */
     error DeployerImplementationDeprecated(address implementation);
-
-    /**
-     * @dev The namespace is empty
-     */
-    error DeployerNamespaceEmpty();
-
-    /**
-     * @dev The name is empty
-     */
-    error DeployerNameEmpty();
 
     /**
      * @dev Emitted every time an authorizer is deployed

--- a/packages/deployer/test/Deployer.test.ts
+++ b/packages/deployer/test/Deployer.test.ts
@@ -125,7 +125,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deployAuthorizer(namespace, name, { impl: authorizer.address, owners: [sender.address] })
-          ).to.be.revertedWith('DeployerImplDeprecated')
+          ).to.be.revertedWith('DeployerImplementationDeprecated')
         })
       })
     })
@@ -134,7 +134,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deployAuthorizer(namespace, name, { impl: authorizer.address, owners: [sender.address] })
-        ).to.be.revertedWith('DeployerImplNotRegistered')
+        ).to.be.revertedWith('DeployerImplementationNotRegistered')
       })
     })
   })
@@ -262,7 +262,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deployPriceOracle(namespace, name, { impl: priceOracle.address, ...priceOracleParams })
-          ).to.be.revertedWith('DeployerImplDeprecated')
+          ).to.be.revertedWith('DeployerImplementationDeprecated')
         })
       })
     })
@@ -271,7 +271,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deployPriceOracle(namespace, name, { impl: priceOracle.address, ...priceOracleParams })
-        ).to.be.revertedWith('DeployerImplNotRegistered')
+        ).to.be.revertedWith('DeployerImplementationNotRegistered')
       })
     })
   })
@@ -390,7 +390,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deploySmartVault(namespace, name, { impl: smartVault.address, ...smartVaultParams })
-          ).to.be.revertedWith('DeployerImplDeprecated')
+          ).to.be.revertedWith('DeployerImplementationDeprecated')
         })
       })
     })
@@ -399,7 +399,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deploySmartVault(namespace, name, { impl: smartVault.address, ...smartVaultParams })
-        ).to.be.revertedWith('DeployerImplNotRegistered')
+        ).to.be.revertedWith('DeployerImplementationNotRegistered')
       })
     })
   })
@@ -520,7 +520,7 @@ describe('Deployer', () => {
 
         it('reverts', async () => {
           await expect(deployer.deployTask(namespace, name, { impl: task.address, initializeData })).to.be.revertedWith(
-            'DeployerImplDeprecated'
+            'DeployerImplementationDeprecated'
           )
         })
       })
@@ -529,7 +529,7 @@ describe('Deployer', () => {
     context('when the implementation is not registered', () => {
       it('reverts', async () => {
         await expect(deployer.deployTask(namespace, name, { impl: task.address, initializeData })).to.be.revertedWith(
-          'DeployerImplNotRegistered'
+          'DeployerImplementationNotRegistered'
         )
       })
     })

--- a/packages/deployer/test/Deployer.test.ts
+++ b/packages/deployer/test/Deployer.test.ts
@@ -125,7 +125,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deployAuthorizer(namespace, name, { impl: authorizer.address, owners: [sender.address] })
-          ).to.be.revertedWith('DEPLOYER_IMPL_DEPRECATED')
+          ).to.be.revertedWith('DeployerImplDeprecated')
         })
       })
     })
@@ -134,7 +134,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deployAuthorizer(namespace, name, { impl: authorizer.address, owners: [sender.address] })
-        ).to.be.revertedWith('DEPLOYER_IMPL_NOT_REGISTERED')
+        ).to.be.revertedWith('DeployerImplNotRegistered')
       })
     })
   })
@@ -262,7 +262,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deployPriceOracle(namespace, name, { impl: priceOracle.address, ...priceOracleParams })
-          ).to.be.revertedWith('DEPLOYER_IMPL_DEPRECATED')
+          ).to.be.revertedWith('DeployerImplDeprecated')
         })
       })
     })
@@ -271,7 +271,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deployPriceOracle(namespace, name, { impl: priceOracle.address, ...priceOracleParams })
-        ).to.be.revertedWith('DEPLOYER_IMPL_NOT_REGISTERED')
+        ).to.be.revertedWith('DeployerImplNotRegistered')
       })
     })
   })
@@ -390,7 +390,7 @@ describe('Deployer', () => {
         it('reverts', async () => {
           await expect(
             deployer.deploySmartVault(namespace, name, { impl: smartVault.address, ...smartVaultParams })
-          ).to.be.revertedWith('DEPLOYER_IMPL_DEPRECATED')
+          ).to.be.revertedWith('DeployerImplDeprecated')
         })
       })
     })
@@ -399,7 +399,7 @@ describe('Deployer', () => {
       it('reverts', async () => {
         await expect(
           deployer.deploySmartVault(namespace, name, { impl: smartVault.address, ...smartVaultParams })
-        ).to.be.revertedWith('DEPLOYER_IMPL_NOT_REGISTERED')
+        ).to.be.revertedWith('DeployerImplNotRegistered')
       })
     })
   })
@@ -520,7 +520,7 @@ describe('Deployer', () => {
 
         it('reverts', async () => {
           await expect(deployer.deployTask(namespace, name, { impl: task.address, initializeData })).to.be.revertedWith(
-            'DEPLOYER_IMPL_DEPRECATED'
+            'DeployerImplDeprecated'
           )
         })
       })
@@ -529,7 +529,7 @@ describe('Deployer', () => {
     context('when the implementation is not registered', () => {
       it('reverts', async () => {
         await expect(deployer.deployTask(namespace, name, { impl: task.address, initializeData })).to.be.revertedWith(
-          'DEPLOYER_IMPL_NOT_REGISTERED'
+          'DeployerImplNotRegistered'
         )
       })
     })

--- a/packages/fee-controller/contracts/FeeController.sol
+++ b/packages/fee-controller/contracts/FeeController.sol
@@ -67,7 +67,7 @@ contract FeeController is IFeeController, Ownable {
      */
     function getFee(address smartVault) external view override returns (uint256 max, uint256 pct, address collector) {
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
 
         pct = fee.pct;
         max = fee.maxPct;
@@ -119,7 +119,7 @@ contract FeeController is IFeeController, Ownable {
     function setFeeCollector(address smartVault, address collector) external override onlyOwner {
         if (collector == address(0)) revert FeeControllerCollectorZero();
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
         fee.collector = collector;
         emit FeeCollectorSet(smartVault, collector);
     }
@@ -141,7 +141,7 @@ contract FeeController is IFeeController, Ownable {
      */
     function _setFeePercentage(address smartVault, uint256 pct) private {
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
         if (pct > fee.maxPct) revert FeeControllerPctAboveMax(smartVault, pct, fee.maxPct);
         fee.pct = pct;
         emit FeePercentageSet(smartVault, pct);

--- a/packages/fee-controller/contracts/FeeController.sol
+++ b/packages/fee-controller/contracts/FeeController.sol
@@ -117,7 +117,7 @@ contract FeeController is IFeeController, Ownable {
      * @param collector Fee collector to be set
      */
     function setFeeCollector(address smartVault, address collector) external override onlyOwner {
-        if (collector == address(0)) revert FeeControllerCollectorZero(smartVault);
+        if (collector == address(0)) revert FeeControllerCollectorZero();
         Fee storage fee = _fees[smartVault];
         if (fee.maxPct == 0) revert FeeControllerSvNotSet(smartVault);
         fee.collector = collector;

--- a/packages/fee-controller/contracts/FeeController.sol
+++ b/packages/fee-controller/contracts/FeeController.sol
@@ -67,7 +67,7 @@ contract FeeController is IFeeController, Ownable {
      */
     function getFee(address smartVault) external view override returns (uint256 max, uint256 pct, address collector) {
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerMaxPctNotSet(smartVault);
 
         pct = fee.pct;
         max = fee.maxPct;
@@ -88,11 +88,11 @@ contract FeeController is IFeeController, Ownable {
      * @param maxPct Max fee percentage to be set
      */
     function setMaxFeePercentage(address smartVault, uint256 maxPct) external override onlyOwner {
-        if (maxPct == 0) revert FeeControllerMaxPctZero(smartVault);
+        if (maxPct == 0) revert FeeControllerMaxPctZero();
 
         Fee storage fee = _fees[smartVault];
         if (fee.maxPct == 0) {
-            if (maxPct >= FixedPoint.ONE) revert FeeControllerMaxPctAboveOne(smartVault);
+            if (maxPct >= FixedPoint.ONE) revert FeeControllerMaxPctAboveOne();
         } else {
             if (maxPct >= fee.maxPct) revert FeeControllerMaxPctAbovePrevious(smartVault, maxPct, fee.maxPct);
         }
@@ -119,7 +119,7 @@ contract FeeController is IFeeController, Ownable {
     function setFeeCollector(address smartVault, address collector) external override onlyOwner {
         if (collector == address(0)) revert FeeControllerCollectorZero();
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerMaxPctNotSet(smartVault);
         fee.collector = collector;
         emit FeeCollectorSet(smartVault, collector);
     }
@@ -141,7 +141,7 @@ contract FeeController is IFeeController, Ownable {
      */
     function _setFeePercentage(address smartVault, uint256 pct) private {
         Fee storage fee = _fees[smartVault];
-        if (fee.maxPct == 0) revert FeeControllerSvMaxPctNotSet(smartVault);
+        if (fee.maxPct == 0) revert FeeControllerMaxPctNotSet(smartVault);
         if (pct > fee.maxPct) revert FeeControllerPctAboveMax(smartVault, pct, fee.maxPct);
         fee.pct = pct;
         emit FeePercentageSet(smartVault, pct);

--- a/packages/fee-controller/contracts/interfaces/IFeeController.sol
+++ b/packages/fee-controller/contracts/interfaces/IFeeController.sol
@@ -19,34 +19,34 @@ pragma solidity >=0.8.0;
  */
 interface IFeeController {
     /**
-     * @dev No max percentage has been set for the requested smart vault
-     */
-    error FeeControllerSvMaxPctNotSet(address smartVault);
-
-    /**
-     * @dev The requested max percentage to be set is zero
-     */
-    error FeeControllerMaxPctZero(address smartVault);
-
-    /**
-     * @dev The requested max percentage to be set is above one
-     */
-    error FeeControllerMaxPctAboveOne(address smartVault);
-
-    /**
-     * @dev The requested max percentage to be set is above the previous max percentage set
-     */
-    error FeeControllerMaxPctAbovePrevious(address smartVault, uint256 requestedMaxPct, uint256 previousMaxPct);
-
-    /**
      * @dev The collector to be set is zero
      */
     error FeeControllerCollectorZero();
 
     /**
+     * @dev The requested max percentage to be set is zero
+     */
+    error FeeControllerMaxPctZero();
+
+    /**
+     * @dev The requested max percentage to be set is above one
+     */
+    error FeeControllerMaxPctAboveOne();
+
+    /**
+     * @dev No max percentage has been set for the requested smart vault
+     */
+    error FeeControllerMaxPctNotSet(address smartVault);
+
+    /**
      * @dev The requested percentage to be set is above the smart vault's max percentage
      */
     error FeeControllerPctAboveMax(address smartVault, uint256 pct, uint256 maxPct);
+
+    /**
+     * @dev The requested max percentage to be set is above the previous max percentage set
+     */
+    error FeeControllerMaxPctAbovePrevious(address smartVault, uint256 requestedMaxPct, uint256 previousMaxPct);
 
     /**
      * @dev Emitted every time a default fee collector is set

--- a/packages/fee-controller/contracts/interfaces/IFeeController.sol
+++ b/packages/fee-controller/contracts/interfaces/IFeeController.sol
@@ -41,7 +41,7 @@ interface IFeeController {
     /**
      * @dev The collector to be set is zero
      */
-    error FeeControllerCollectorZero(address smartVault);
+    error FeeControllerCollectorZero();
 
     /**
      * @dev The pct to be set is above the maxPct

--- a/packages/fee-controller/contracts/interfaces/IFeeController.sol
+++ b/packages/fee-controller/contracts/interfaces/IFeeController.sol
@@ -19,24 +19,24 @@ pragma solidity >=0.8.0;
  */
 interface IFeeController {
     /**
-     * @dev The smart vault's fee maxPct is zero
+     * @dev No max percentage has been set for the requested smart vault
      */
     error FeeControllerSvMaxPctNotSet(address smartVault);
 
     /**
-     * @dev The maxPct to be set is zero
+     * @dev The requested max percentage to be set is zero
      */
     error FeeControllerMaxPctZero(address smartVault);
 
     /**
-     * @dev The maxPct to be set is above one
+     * @dev The requested max percentage to be set is above one
      */
     error FeeControllerMaxPctAboveOne(address smartVault);
 
     /**
-     * @dev The maxPct to be set is above the previous maxPct
+     * @dev The requested max percentage to be set is above the previous max percentage set
      */
-    error FeeControllerMaxPctAbovePrevious(address smartVault, uint256 maxPct, uint256 previousMaxPct);
+    error FeeControllerMaxPctAbovePrevious(address smartVault, uint256 requestedMaxPct, uint256 previousMaxPct);
 
     /**
      * @dev The collector to be set is zero
@@ -44,7 +44,7 @@ interface IFeeController {
     error FeeControllerCollectorZero();
 
     /**
-     * @dev The pct to be set is above the maxPct
+     * @dev The requested percentage to be set is above the smart vault's max percentage
      */
     error FeeControllerPctAboveMax(address smartVault, uint256 pct, uint256 maxPct);
 

--- a/packages/fee-controller/contracts/interfaces/IFeeController.sol
+++ b/packages/fee-controller/contracts/interfaces/IFeeController.sol
@@ -21,7 +21,7 @@ interface IFeeController {
     /**
      * @dev The smart vault's fee maxPct is zero
      */
-    error FeeControllerSvNotSet(address smartVault);
+    error FeeControllerSvMaxPctNotSet(address smartVault);
 
     /**
      * @dev The maxPct to be set is zero

--- a/packages/fee-controller/contracts/interfaces/IFeeController.sol
+++ b/packages/fee-controller/contracts/interfaces/IFeeController.sol
@@ -19,6 +19,36 @@ pragma solidity >=0.8.0;
  */
 interface IFeeController {
     /**
+     * @dev The smart vault's fee maxPct is zero
+     */
+    error FeeControllerSvNotSet(address smartVault);
+
+    /**
+     * @dev The maxPct to be set is zero
+     */
+    error FeeControllerMaxPctZero(address smartVault);
+
+    /**
+     * @dev The maxPct to be set is above one
+     */
+    error FeeControllerMaxPctAboveOne(address smartVault);
+
+    /**
+     * @dev The maxPct to be set is above the previous maxPct
+     */
+    error FeeControllerMaxPctAbovePrevious(address smartVault, uint256 maxPct, uint256 previousMaxPct);
+
+    /**
+     * @dev The collector to be set is zero
+     */
+    error FeeControllerCollectorZero(address smartVault);
+
+    /**
+     * @dev The pct to be set is above the maxPct
+     */
+    error FeeControllerPctAboveMax(address smartVault, uint256 pct, uint256 maxPct);
+
+    /**
      * @dev Emitted every time a default fee collector is set
      */
     event DefaultFeeCollectorSet(address indexed collector);

--- a/packages/fee-controller/test/FeeController.test.ts
+++ b/packages/fee-controller/test/FeeController.test.ts
@@ -22,7 +22,7 @@ describe('FeeController', () => {
     it('sets the default collector correctly', async () => {
       expect(await feeController.defaultFeeCollector()).to.be.equal(collector.address)
       expect(await feeController.hasFee(smartVault)).to.be.false
-      await expect(feeController.getFee(smartVault)).to.be.revertedWith('FeeControllerSvMaxPctNotSet')
+      await expect(feeController.getFee(smartVault)).to.be.revertedWith('FeeControllerMaxPctNotSet')
     })
 
     it('sets the owner correctly', async () => {
@@ -235,7 +235,7 @@ describe('FeeController', () => {
 
         it('reverts', async () => {
           await expect(feeController.setFeePercentage(smartVault, feePct)).to.be.revertedWith(
-            'FeeControllerSvMaxPctNotSet'
+            'FeeControllerMaxPctNotSet'
           )
         })
       })
@@ -281,7 +281,7 @@ describe('FeeController', () => {
         context('when there was no max set for the given smart vault', () => {
           it('reverts', async () => {
             await expect(feeController.setFeeCollector(smartVault, newCollector)).to.be.revertedWith(
-              'FeeControllerSvMaxPctNotSet'
+              'FeeControllerMaxPctNotSet'
             )
           })
         })

--- a/packages/fee-controller/test/FeeController.test.ts
+++ b/packages/fee-controller/test/FeeController.test.ts
@@ -22,7 +22,7 @@ describe('FeeController', () => {
     it('sets the default collector correctly', async () => {
       expect(await feeController.defaultFeeCollector()).to.be.equal(collector.address)
       expect(await feeController.hasFee(smartVault)).to.be.false
-      await expect(feeController.getFee(smartVault)).to.be.revertedWith('FEE_CONTROLLER_SV_NOT_SET')
+      await expect(feeController.getFee(smartVault)).to.be.revertedWith('FeeControllerSvMaxPctNotSet')
     })
 
     it('sets the owner correctly', async () => {
@@ -53,7 +53,7 @@ describe('FeeController', () => {
 
         it('reverts', async () => {
           await expect(feeController.setDefaultFeeCollector(newCollector)).to.be.revertedWith(
-            'FEE_CONTROLLER_COLLECTOR_ZERO'
+            'FeeControllerCollectorZero'
           )
         })
       })
@@ -125,7 +125,7 @@ describe('FeeController', () => {
 
           it('reverts', async () => {
             await expect(feeController.setMaxFeePercentage(smartVault, newFeePct)).to.be.revertedWith(
-              'FEE_CONTROLLER_MAX_PCT_ABOVE_ONE'
+              'FeeControllerMaxPctAboveOne'
             )
           })
         })
@@ -173,7 +173,7 @@ describe('FeeController', () => {
 
           it('reverts', async () => {
             await expect(feeController.setMaxFeePercentage(smartVault, maxPct)).to.be.revertedWith(
-              'FEE_CONTROLLER_MAX_PCT_ABOVE_PRE'
+              'FeeControllerMaxPctAbovePrevious'
             )
           })
         })
@@ -224,7 +224,7 @@ describe('FeeController', () => {
 
           it('reverts', async () => {
             await expect(feeController.setFeePercentage(smartVault, feePct)).to.be.revertedWith(
-              'FEE_CONTROLLER_PCT_ABOVE_MAX'
+              'FeeControllerPctAboveMax'
             )
           })
         })
@@ -235,7 +235,7 @@ describe('FeeController', () => {
 
         it('reverts', async () => {
           await expect(feeController.setFeePercentage(smartVault, feePct)).to.be.revertedWith(
-            'FEE_CONTROLLER_SV_NOT_SET'
+            'FeeControllerSvMaxPctNotSet'
           )
         })
       })
@@ -281,7 +281,7 @@ describe('FeeController', () => {
         context('when there was no max set for the given smart vault', () => {
           it('reverts', async () => {
             await expect(feeController.setFeeCollector(smartVault, newCollector)).to.be.revertedWith(
-              'FEE_CONTROLLER_SV_NOT_SET'
+              'FeeControllerSvMaxPctNotSet'
             )
           })
         })
@@ -292,7 +292,7 @@ describe('FeeController', () => {
 
         it('reverts', async () => {
           await expect(feeController.setFeeCollector(smartVault, collector)).to.be.revertedWith(
-            'FEE_CONTROLLER_COLLECTOR_ZERO'
+            'FeeControllerCollectorZero'
           )
         })
       })

--- a/packages/helpers/contracts/math/FixedPoint.sol
+++ b/packages/helpers/contracts/math/FixedPoint.sol
@@ -25,17 +25,17 @@ library FixedPoint {
     /**
      * @dev Multiplication overflow
      */
-    error MulOverflow(uint256 a, uint256 b);
+    error FixedPointMulOverflow(uint256 a, uint256 b);
 
     /**
      * @dev Division by zero
      */
-    error ZeroDivision();
+    error FixedPointZeroDivision();
 
     /**
      * @dev Division internal error
      */
-    error DivInternal(uint256 a, uint256 aInflated);
+    error FixedPointDivInternal(uint256 a, uint256 aInflated);
 
     /**
      * @dev Multiplies two fixed point numbers rounding down
@@ -43,7 +43,7 @@ library FixedPoint {
     function mulDown(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            if (a != 0 && product / a != b) revert MulOverflow(a, b);
+            if (a != 0 && product / a != b) revert FixedPointMulOverflow(a, b);
             return product / ONE;
         }
     }
@@ -54,7 +54,7 @@ library FixedPoint {
     function mulUp(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            if (a != 0 && product / a != b) revert MulOverflow(a, b);
+            if (a != 0 && product / a != b) revert FixedPointMulOverflow(a, b);
             return product == 0 ? 0 : (((product - 1) / ONE) + 1);
         }
     }
@@ -64,10 +64,10 @@ library FixedPoint {
      */
     function divDown(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            if (b == 0) revert ZeroDivision();
+            if (b == 0) revert FixedPointZeroDivision();
             if (a == 0) return 0;
             uint256 aInflated = a * ONE;
-            if (aInflated / a != ONE) revert DivInternal(a, aInflated);
+            if (aInflated / a != ONE) revert FixedPointDivInternal(a, aInflated);
             return aInflated / b;
         }
     }
@@ -77,10 +77,10 @@ library FixedPoint {
      */
     function divUp(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            if (b == 0) revert ZeroDivision();
+            if (b == 0) revert FixedPointZeroDivision();
             if (a == 0) return 0;
             uint256 aInflated = a * ONE;
-            if (aInflated / a != ONE) revert DivInternal(a, aInflated);
+            if (aInflated / a != ONE) revert FixedPointDivInternal(a, aInflated);
             return ((aInflated - 1) / b) + 1;
         }
     }

--- a/packages/helpers/contracts/math/FixedPoint.sol
+++ b/packages/helpers/contracts/math/FixedPoint.sol
@@ -23,12 +23,27 @@ library FixedPoint {
     uint256 internal constant ONE = 1e18;
 
     /**
+     * @dev Multiplication overflow
+     */
+    error MulOverflow(uint256 a, uint256 b);
+
+    /**
+     * @dev Division by zero
+     */
+    error ZeroDivision();
+
+    /**
+     * @dev Division internal error
+     */
+    error DivInternal(uint256 a, uint256 aInflated);
+
+    /**
      * @dev Multiplies two fixed point numbers rounding down
      */
     function mulDown(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            require(a == 0 || product / a == b, 'MUL_OVERFLOW');
+            if (a !=0 && product / a != b) revert MulOverflow(a, b);
             return product / ONE;
         }
     }
@@ -39,7 +54,7 @@ library FixedPoint {
     function mulUp(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            require(a == 0 || product / a == b, 'MUL_OVERFLOW');
+            if (a !=0 && product / a != b) revert MulOverflow(a, b);
             return product == 0 ? 0 : (((product - 1) / ONE) + 1);
         }
     }
@@ -49,10 +64,10 @@ library FixedPoint {
      */
     function divDown(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            require(b != 0, 'ZERO_DIVISION');
+            if (b == 0) revert ZeroDivision();
             if (a == 0) return 0;
             uint256 aInflated = a * ONE;
-            require(aInflated / a == ONE, 'DIV_INTERNAL');
+            if (aInflated / a != ONE) revert DivInternal(a, aInflated);
             return aInflated / b;
         }
     }
@@ -62,10 +77,10 @@ library FixedPoint {
      */
     function divUp(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            require(b != 0, 'ZERO_DIVISION');
+            if (b == 0) revert ZeroDivision();
             if (a == 0) return 0;
             uint256 aInflated = a * ONE;
-            require(aInflated / a == ONE, 'DIV_INTERNAL');
+            if (aInflated / a != ONE) revert DivInternal(a, aInflated);
             return ((aInflated - 1) / b) + 1;
         }
     }

--- a/packages/helpers/contracts/math/FixedPoint.sol
+++ b/packages/helpers/contracts/math/FixedPoint.sol
@@ -43,7 +43,7 @@ library FixedPoint {
     function mulDown(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            if (a !=0 && product / a != b) revert MulOverflow(a, b);
+            if (a != 0 && product / a != b) revert MulOverflow(a, b);
             return product / ONE;
         }
     }
@@ -54,7 +54,7 @@ library FixedPoint {
     function mulUp(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
             uint256 product = a * b;
-            if (a !=0 && product / a != b) revert MulOverflow(a, b);
+            if (a != 0 && product / a != b) revert MulOverflow(a, b);
             return product == 0 ? 0 : (((product - 1) / ONE) + 1);
         }
     }

--- a/packages/helpers/contracts/utils/BytesHelpers.sol
+++ b/packages/helpers/contracts/utils/BytesHelpers.sol
@@ -20,6 +20,11 @@ pragma solidity ^0.8.0;
  */
 library BytesHelpers {
     /**
+     * @dev The length is shorter than start plus 32
+     */
+    error BytesOutOfBounds(uint256 start, uint256 length);
+
+    /**
      * @dev Concatenates an address to a bytes array
      */
     function concat(bytes memory self, address value) internal pure returns (bytes memory) {
@@ -44,7 +49,7 @@ library BytesHelpers {
      * @dev Reads an uint256 from a bytes array starting at a given position
      */
     function toUint256(bytes memory self, uint256 start) internal pure returns (uint256 result) {
-        require(self.length >= start + 32, 'BYTES_OUT_OF_BOUNDS');
+        if (self.length < start + 32) revert BytesOutOfBounds(start, self.length);
         assembly {
             result := mload(add(add(self, 0x20), start))
         }

--- a/packages/helpers/contracts/utils/EnumerableMap.sol
+++ b/packages/helpers/contracts/utils/EnumerableMap.sol
@@ -108,7 +108,7 @@ library EnumerableMap {
      *
      * Requirements:
      *
-     * - `index` must be strictly less than {length}.
+     * - `index` must be strictly lower than {length}.
      */
     function at(AddressToUintMap storage map, uint256 index) internal view returns (address, uint256) {
         address key = map._keys.at(index);

--- a/packages/helpers/contracts/utils/EnumerableMap.sol
+++ b/packages/helpers/contracts/utils/EnumerableMap.sol
@@ -31,12 +31,20 @@ import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 library EnumerableMap {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    // AddressToUintMap
-
+    /**
+     * @dev Address to uint map
+     * @param _keys Set of map keys
+     * @param _values Map of values
+     */
     struct AddressToUintMap {
         EnumerableSet.AddressSet _keys;
         mapping (address => uint256) _values;
     }
+
+    /**
+     * @dev The key doesn't exist in the map
+     */
+    error EnumerableMapNonExistentKey(address indexed key);
 
     /**
      * @dev Adds a key-value pair to a map, or updates the value for an existing
@@ -116,7 +124,7 @@ library EnumerableMap {
      */
     function get(AddressToUintMap storage map, address key) internal view returns (uint256) {
         uint256 value = map._values[key];
-        require(value != 0 || contains(map, key), 'EnumerableMap: nonexistent key');
+        if (value == 0 && !contains(map, key)) revert EnumerableMapNonExistentKey(key);
         return value;
     }
 
@@ -217,7 +225,7 @@ library EnumerableMap {
      */
     function get(AddressToAddressMap storage map, address key) internal view returns (address) {
         address value = map._values[key];
-        require(value != address(0) || contains(map, key), 'EnumerableMap: nonexistent key');
+        if (value == 0 && !contains(map, key)) revert EnumerableMapNonExistentKey(key);
         return value;
     }
 

--- a/packages/helpers/contracts/utils/EnumerableMap.sol
+++ b/packages/helpers/contracts/utils/EnumerableMap.sol
@@ -44,7 +44,7 @@ library EnumerableMap {
     /**
      * @dev The key doesn't exist in the map
      */
-    error EnumerableMapNonExistentKey(address indexed key);
+    error EnumerableMapNonExistentKey(address key);
 
     /**
      * @dev Adds a key-value pair to a map, or updates the value for an existing
@@ -225,7 +225,7 @@ library EnumerableMap {
      */
     function get(AddressToAddressMap storage map, address key) internal view returns (address) {
         address value = map._values[key];
-        if (value == 0 && !contains(map, key)) revert EnumerableMapNonExistentKey(key);
+        if (value == address(0) && !contains(map, key)) revert EnumerableMapNonExistentKey(key);
         return value;
     }
 

--- a/packages/helpers/test/contracts/math/FixedPoint.test.ts
+++ b/packages/helpers/test/contracts/math/FixedPoint.test.ts
@@ -34,7 +34,7 @@ describe('FixedPoint', () => {
       expect(await library.divUp(1, 1)).to.be.equal(fp(1))
       expect(await library.divUp(0, fp(2))).to.be.equal(0)
       expect(await library.divUp(fp(2), fp(2))).to.be.equal(fp(1))
-      await expect(library.divUp(fp(2), 0)).to.be.revertedWith('ZERO_DIVISION')
+      await expect(library.divUp(fp(2), 0)).to.be.revertedWith('ZeroDivision')
     })
   })
 
@@ -43,7 +43,7 @@ describe('FixedPoint', () => {
       expect(await library.divDown(1, 1)).to.be.equal(fp(1))
       expect(await library.divDown(0, fp(2))).to.be.equal(0)
       expect(await library.divDown(fp(2), fp(2))).to.be.equal(fp(1))
-      await expect(library.divDown(fp(2), 0)).to.be.revertedWith('ZERO_DIVISION')
+      await expect(library.divDown(fp(2), 0)).to.be.revertedWith('ZeroDivision')
     })
   })
 })

--- a/packages/helpers/test/contracts/math/FixedPoint.test.ts
+++ b/packages/helpers/test/contracts/math/FixedPoint.test.ts
@@ -34,7 +34,7 @@ describe('FixedPoint', () => {
       expect(await library.divUp(1, 1)).to.be.equal(fp(1))
       expect(await library.divUp(0, fp(2))).to.be.equal(0)
       expect(await library.divUp(fp(2), fp(2))).to.be.equal(fp(1))
-      await expect(library.divUp(fp(2), 0)).to.be.revertedWith('ZeroDivision')
+      await expect(library.divUp(fp(2), 0)).to.be.revertedWith('FixedPointZeroDivision')
     })
   })
 
@@ -43,7 +43,7 @@ describe('FixedPoint', () => {
       expect(await library.divDown(1, 1)).to.be.equal(fp(1))
       expect(await library.divDown(0, fp(2))).to.be.equal(0)
       expect(await library.divDown(fp(2), fp(2))).to.be.equal(fp(1))
-      await expect(library.divDown(fp(2), 0)).to.be.revertedWith('ZeroDivision')
+      await expect(library.divDown(fp(2), 0)).to.be.revertedWith('FixedPointZeroDivision')
     })
   })
 })

--- a/packages/helpers/test/contracts/utils/BytesHelpers.test.ts
+++ b/packages/helpers/test/contracts/utils/BytesHelpers.test.ts
@@ -21,8 +21,8 @@ describe('BytesHelpers', () => {
     })
 
     it('reverts if out of bounds', async () => {
-      await expect(library.toUint256(bytes, 64)).to.be.revertedWith('BYTES_OUT_OF_BOUNDS')
-      await expect(library.toUint256(bytes, 33)).to.be.revertedWith('BYTES_OUT_OF_BOUNDS')
+      await expect(library.toUint256(bytes, 64)).to.be.revertedWith('BytesOutOfBounds')
+      await expect(library.toUint256(bytes, 33)).to.be.revertedWith('BytesOutOfBounds')
     })
   })
 

--- a/packages/helpers/test/contracts/utils/EnumerableMap.test.ts
+++ b/packages/helpers/test/contracts/utils/EnumerableMap.test.ts
@@ -147,7 +147,7 @@ describe('EnumerableMap', () => {
         })
 
         it('missing value', async () => {
-          await expect(map.get(keyB)).to.be.revertedWith('EnumerableMap: nonexistent key')
+          await expect(map.get(keyB)).to.be.revertedWith('EnumerableMapNonExistentKey')
         })
       })
 
@@ -299,7 +299,7 @@ describe('EnumerableMap', () => {
         })
 
         it('missing value', async () => {
-          await expect(map.get(keyB)).to.be.revertedWith('EnumerableMap: nonexistent key')
+          await expect(map.get(keyB)).to.be.revertedWith('EnumerableMapNonExistentKey')
         })
       })
 

--- a/packages/price-oracle/contracts/PriceOracle.sol
+++ b/packages/price-oracle/contracts/PriceOracle.sol
@@ -152,9 +152,8 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         uint256 baseDecimals = IERC20Metadata(base).decimals();
         uint256 quoteDecimals = IERC20Metadata(quote).decimals();
 
-        // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
-        if (baseDecimals > quoteDecimals + FP_DECIMALS)
-            revert PriceOracleBaseDecimalsTooBig(base, quote, baseDecimals, quoteDecimals);
+        bool areBaseDecimalsTooBig = baseDecimals > quoteDecimals + FP_DECIMALS;
+        if (areBaseDecimalsTooBig) revert PriceOracleBaseDecimalsTooBig(base, baseDecimals, quote, quoteDecimals);
 
         // No need for checked math as we are checking it manually beforehand
         uint256 resultDecimals = quoteDecimals + FP_DECIMALS - baseDecimals;
@@ -177,7 +176,8 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         for (uint256 i = 0; i < prices.length; i++) {
             PriceData memory price = prices[i];
             if (price.base == base && price.quote == quote) {
-                if (price.deadline < block.timestamp) revert PriceOraclePriceOutdated(base, quote, price.deadline);
+                bool isPastDeadline = price.deadline < block.timestamp;
+                if (isPastDeadline) revert PriceOracleOutdatedPrice(base, quote, price.deadline, block.timestamp);
                 return price.rate;
             }
         }
@@ -250,12 +250,11 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
      */
     function _getInversePrice(address inverseFeed) internal view returns (uint256 price, uint256 decimals) {
         (uint256 inversePrice, uint256 inverseFeedDecimals) = _getFeedData(inverseFeed);
-        if (inverseFeedDecimals > INVERSE_FEED_MAX_DECIMALS)
-            revert PriceOracleInverseFeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
+        bool areInverseFeedDecimalsTooBig = inverseFeedDecimals > INVERSE_FEED_MAX_DECIMALS;
+        if (areInverseFeedDecimalsTooBig) revert PriceOracleInverseFeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
 
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy
         price = FixedPoint.ONE.divDown(inversePrice);
-        // No need for checked math as we are checking it manually beforehand
         decimals = INVERSE_FEED_MAX_DECIMALS - inverseFeedDecimals;
     }
 
@@ -274,14 +273,12 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         (uint256 basePrice, uint256 baseFeedDecimals) = _getFeedData(baseFeed);
         (uint256 quotePrice, uint256 quoteFeedDecimals) = _getFeedData(quoteFeed);
 
-        // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
-        if (quoteFeedDecimals > baseFeedDecimals + FP_DECIMALS)
-            revert PriceOracleQuoteFeedDecimalsTooBig(quoteFeed, quoteFeedDecimals, baseFeed, baseFeedDecimals);
+        bool areQuoteFeedDecimalsTooBig = quoteFeedDecimals > baseFeedDecimals + FP_DECIMALS;
+        if (areQuoteFeedDecimalsTooBig) revert PriceOracleQuoteFeedDecimalsTooBig(quoteFeedDecimals, baseFeedDecimals);
 
         // Price is base/quote = (base/pivot) / (quote/pivot)
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy
         price = basePrice.divDown(quotePrice);
-        // No need for checked math as we are checking it manually beforehand
         decimals = baseFeedDecimals + FP_DECIMALS - quoteFeedDecimals;
     }
 
@@ -308,7 +305,9 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
 
         (PriceData[] memory prices, bytes memory signature) = abi.decode(data, (PriceData[], bytes));
         (address recovered, ECDSA.RecoverError error) = ECDSA.tryRecover(getPricesDigest(prices), signature);
-        if (error != ECDSA.RecoverError.NoError || !isSignerAllowed(recovered)) revert OracleInvalidSigner(recovered);
+
+        bool isSignerValid = error == ECDSA.RecoverError.NoError && isSignerAllowed(recovered);
+        if (!isSignerValid) revert PriceOracleInvalidSigner(recovered);
         return prices;
     }
 

--- a/packages/price-oracle/contracts/PriceOracle.sol
+++ b/packages/price-oracle/contracts/PriceOracle.sol
@@ -153,7 +153,8 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         uint256 quoteDecimals = IERC20Metadata(quote).decimals();
 
         // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
-        if (baseDecimals > quoteDecimals + FP_DECIMALS) revert BaseDecimalsTooBig(base, quote, baseDecimals, quoteDecimals);
+        if (baseDecimals > quoteDecimals + FP_DECIMALS)
+            revert BaseDecimalsTooBig(base, quote, baseDecimals, quoteDecimals);
 
         // No need for checked math as we are checking it manually beforehand
         uint256 resultDecimals = quoteDecimals + FP_DECIMALS - baseDecimals;
@@ -249,7 +250,8 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
      */
     function _getInversePrice(address inverseFeed) internal view returns (uint256 price, uint256 decimals) {
         (uint256 inversePrice, uint256 inverseFeedDecimals) = _getFeedData(inverseFeed);
-        if (inverseFeedDecimals > INVERSE_FEED_MAX_DECIMALS) revert FeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
+        if (inverseFeedDecimals > INVERSE_FEED_MAX_DECIMALS)
+            revert FeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
 
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy
         price = FixedPoint.ONE.divDown(inversePrice);
@@ -273,7 +275,8 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         (uint256 quotePrice, uint256 quoteFeedDecimals) = _getFeedData(quoteFeed);
 
         // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
-        if (quoteFeedDecimals > baseFeedDecimals + FP_DECIMALS) revert QuoteFeedDecimalsTooBig(quoteFeed, quoteFeedDecimals, baseFeed, baseFeedDecimals);
+        if (quoteFeedDecimals > baseFeedDecimals + FP_DECIMALS)
+            revert QuoteFeedDecimalsTooBig(quoteFeed, quoteFeedDecimals, baseFeed, baseFeedDecimals);
 
         // Price is base/quote = (base/pivot) / (quote/pivot)
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy

--- a/packages/price-oracle/contracts/PriceOracle.sol
+++ b/packages/price-oracle/contracts/PriceOracle.sol
@@ -154,7 +154,7 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
 
         // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
         if (baseDecimals > quoteDecimals + FP_DECIMALS)
-            revert BaseDecimalsTooBig(base, quote, baseDecimals, quoteDecimals);
+            revert PriceOracleBaseDecimalsTooBig(base, quote, baseDecimals, quoteDecimals);
 
         // No need for checked math as we are checking it manually beforehand
         uint256 resultDecimals = quoteDecimals + FP_DECIMALS - baseDecimals;
@@ -177,7 +177,7 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         for (uint256 i = 0; i < prices.length; i++) {
             PriceData memory price = prices[i];
             if (price.base == base && price.quote == quote) {
-                if (price.deadline < block.timestamp) revert OraclePriceOutdated(base, quote, price.deadline);
+                if (price.deadline < block.timestamp) revert PriceOraclePriceOutdated(base, quote, price.deadline);
                 return price.rate;
             }
         }
@@ -227,7 +227,7 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
         address quoteFeed = getFeed[quote][pivot];
         if (baseFeed != address(0) && quoteFeed != address(0)) return _getPivotPrice(baseFeed, quoteFeed);
 
-        revert OracleMissingFeed(base, quote);
+        revert PriceOracleMissingFeed(base, quote);
     }
 
     /**
@@ -251,7 +251,7 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
     function _getInversePrice(address inverseFeed) internal view returns (uint256 price, uint256 decimals) {
         (uint256 inversePrice, uint256 inverseFeedDecimals) = _getFeedData(inverseFeed);
         if (inverseFeedDecimals > INVERSE_FEED_MAX_DECIMALS)
-            revert FeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
+            revert PriceOracleInverseFeedDecimalsTooBig(inverseFeed, inverseFeedDecimals);
 
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy
         price = FixedPoint.ONE.divDown(inversePrice);
@@ -276,7 +276,7 @@ contract PriceOracle is IPriceOracle, Authorized, ReentrancyGuardUpgradeable {
 
         // No need for checked math as an uint8 + FP_DECIMALS (constant) will always fit in an uint256
         if (quoteFeedDecimals > baseFeedDecimals + FP_DECIMALS)
-            revert QuoteFeedDecimalsTooBig(quoteFeed, quoteFeedDecimals, baseFeed, baseFeedDecimals);
+            revert PriceOracleQuoteFeedDecimalsTooBig(quoteFeed, quoteFeedDecimals, baseFeed, baseFeedDecimals);
 
         // Price is base/quote = (base/pivot) / (quote/pivot)
         // Prices are requested for different purposes, we are rounding down always to follow a single strategy

--- a/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
+++ b/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
@@ -43,6 +43,36 @@ interface IPriceOracle is IAuthorized {
     }
 
     /**
+     * @dev The base decimals are bigger than the quote decimals plus the fixed point decimals
+     */
+    error BaseDecimalsTooBig(address base, address quote, uint256 baseDecimals, uint256 quoteDecimals);
+
+    /**
+     * @dev The price deadline is is in the past
+     */
+    error OraclePriceOutdated(address base, address quote, uint256 deadline);
+
+    /**
+     * @dev The feed for the given (base, quote) pair doesn't exist
+     */
+    error OracleMissingFeed(address base, address quote);
+
+    /**
+     * @dev The inverse feed decimals are bigger than the maximum inverse feed decimals
+     */
+    error FeedDecimalsTooBig(address inverseFeed, uint256 inverseFeedDecimals);
+
+    /**
+     * @dev The quote feed decimals are bigger than the base feed decimals plus the fixed point decimals
+     */
+    error QuoteFeedDecimalsTooBig(address quoteFeed, uint256 quoteFeedDecimals, address baseFeed, uint256 baseFeedDecimals);
+
+    /**
+     * @dev The signer is not allowed
+     */
+    error OracleInvalidSigner(address signer);
+
+    /**
      * @dev Emitted every time a signer is changed
      */
     event SignerSet(address indexed signer, bool allowed);

--- a/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
+++ b/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
@@ -43,19 +43,24 @@ interface IPriceOracle is IAuthorized {
     }
 
     /**
-     * @dev The base decimals are bigger than the quote decimals plus the fixed point decimals
+     * @dev The signer is not allowed
      */
-    error PriceOracleBaseDecimalsTooBig(address base, address quote, uint256 baseDecimals, uint256 quoteDecimals);
-
-    /**
-     * @dev The price deadline is is in the past
-     */
-    error PriceOraclePriceOutdated(address base, address quote, uint256 deadline);
+    error PriceOracleInvalidSigner(address signer);
 
     /**
      * @dev The feed for the given (base, quote) pair doesn't exist
      */
     error PriceOracleMissingFeed(address base, address quote);
+
+    /**
+     * @dev The price deadline is in the past
+     */
+    error PriceOracleOutdatedPrice(address base, address quote, uint256 deadline, uint256 currentTimestamp);
+
+    /**
+     * @dev The base decimals are bigger than the quote decimals plus the fixed point decimals
+     */
+    error PriceOracleBaseDecimalsTooBig(address base, uint256 baseDecimals, address quote, uint256 quoteDecimals);
 
     /**
      * @dev The inverse feed decimals are bigger than the maximum inverse feed decimals
@@ -65,17 +70,7 @@ interface IPriceOracle is IAuthorized {
     /**
      * @dev The quote feed decimals are bigger than the base feed decimals plus the fixed point decimals
      */
-    error PriceOracleQuoteFeedDecimalsTooBig(
-        address quoteFeed,
-        uint256 quoteFeedDecimals,
-        address baseFeed,
-        uint256 baseFeedDecimals
-    );
-
-    /**
-     * @dev The signer is not allowed
-     */
-    error OracleInvalidSigner(address signer);
+    error PriceOracleQuoteFeedDecimalsTooBig(uint256 quoteFeedDecimals, uint256 baseFeedDecimals);
 
     /**
      * @dev Emitted every time a signer is changed

--- a/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
+++ b/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
@@ -65,7 +65,12 @@ interface IPriceOracle is IAuthorized {
     /**
      * @dev The quote feed decimals are bigger than the base feed decimals plus the fixed point decimals
      */
-    error QuoteFeedDecimalsTooBig(address quoteFeed, uint256 quoteFeedDecimals, address baseFeed, uint256 baseFeedDecimals);
+    error QuoteFeedDecimalsTooBig(
+        address quoteFeed,
+        uint256 quoteFeedDecimals,
+        address baseFeed,
+        uint256 baseFeedDecimals
+    );
 
     /**
      * @dev The signer is not allowed

--- a/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
+++ b/packages/price-oracle/contracts/interfaces/IPriceOracle.sol
@@ -45,27 +45,27 @@ interface IPriceOracle is IAuthorized {
     /**
      * @dev The base decimals are bigger than the quote decimals plus the fixed point decimals
      */
-    error BaseDecimalsTooBig(address base, address quote, uint256 baseDecimals, uint256 quoteDecimals);
+    error PriceOracleBaseDecimalsTooBig(address base, address quote, uint256 baseDecimals, uint256 quoteDecimals);
 
     /**
      * @dev The price deadline is is in the past
      */
-    error OraclePriceOutdated(address base, address quote, uint256 deadline);
+    error PriceOraclePriceOutdated(address base, address quote, uint256 deadline);
 
     /**
      * @dev The feed for the given (base, quote) pair doesn't exist
      */
-    error OracleMissingFeed(address base, address quote);
+    error PriceOracleMissingFeed(address base, address quote);
 
     /**
      * @dev The inverse feed decimals are bigger than the maximum inverse feed decimals
      */
-    error FeedDecimalsTooBig(address inverseFeed, uint256 inverseFeedDecimals);
+    error PriceOracleInverseFeedDecimalsTooBig(address inverseFeed, uint256 inverseFeedDecimals);
 
     /**
      * @dev The quote feed decimals are bigger than the base feed decimals plus the fixed point decimals
      */
-    error QuoteFeedDecimalsTooBig(
+    error PriceOracleQuoteFeedDecimalsTooBig(
         address quoteFeed,
         uint256 quoteFeedDecimals,
         address baseFeed,

--- a/packages/price-oracle/test/PriceOracle.test.ts
+++ b/packages/price-oracle/test/PriceOracle.test.ts
@@ -1597,7 +1597,7 @@ describe('PriceOracle', () => {
 
     const itRevertsDueToInvalidSignature = () => {
       it('reverts due to invalid signature', async () => {
-        await expect(getPrice()).to.be.revertedWith('OracleInvalidSigner')
+        await expect(getPrice()).to.be.revertedWith('PriceOracleInvalidSigner')
       })
     }
 
@@ -1633,7 +1633,7 @@ describe('PriceOracle', () => {
 
           const itRevertsDueToOutdatedFeed = () => {
             it('reverts due to outdated feed', async () => {
-              await expect(getPrice()).to.be.revertedWith('PriceOraclePriceOutdated')
+              await expect(getPrice()).to.be.revertedWith('PriceOracleOutdatedPrice')
             })
           }
 

--- a/packages/price-oracle/test/PriceOracle.test.ts
+++ b/packages/price-oracle/test/PriceOracle.test.ts
@@ -113,7 +113,7 @@ describe('PriceOracle', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(priceOracle.setSigner(owner.address, true)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(priceOracle.setSigner(owner.address, true)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -169,7 +169,7 @@ describe('PriceOracle', () => {
 
     context('when sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(priceOracle.setFeed(BASE, QUOTE, FEED)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(priceOracle.setFeed(BASE, QUOTE, FEED)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -194,7 +194,7 @@ describe('PriceOracle', () => {
       })
 
       it('reverts', async () => {
-        await expect(getPrice()).to.be.revertedWith('ORACLE_MISSING_FEED')
+        await expect(getPrice()).to.be.revertedWith('OracleMissingFeed')
       })
     })
 
@@ -208,7 +208,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BASE_DECIMALS_TOO_BIG')
+          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
         })
       }
 
@@ -491,7 +491,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BASE_DECIMALS_TOO_BIG')
+          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
         })
       }
 
@@ -787,7 +787,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BASE_DECIMALS_TOO_BIG')
+          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
         })
       }
 
@@ -1591,13 +1591,13 @@ describe('PriceOracle', () => {
 
     const itRevertsDueToMissingFeed = () => {
       it('reverts due to missing feed', async () => {
-        await expect(getPrice()).to.be.revertedWith('ORACLE_MISSING_FEED')
+        await expect(getPrice()).to.be.revertedWith('OracleMissingFeed')
       })
     }
 
     const itRevertsDueToInvalidSignature = () => {
       it('reverts due to invalid signature', async () => {
-        await expect(getPrice()).to.be.revertedWith('ORACLE_INVALID_SIGNER')
+        await expect(getPrice()).to.be.revertedWith('OracleInvalidSigner')
       })
     }
 
@@ -1633,7 +1633,7 @@ describe('PriceOracle', () => {
 
           const itRevertsDueToOutdatedFeed = () => {
             it('reverts due to outdated feed', async () => {
-              await expect(getPrice()).to.be.revertedWith('ORACLE_PRICE_OUTDATED')
+              await expect(getPrice()).to.be.revertedWith('OraclePriceOutdated')
             })
           }
 

--- a/packages/price-oracle/test/PriceOracle.test.ts
+++ b/packages/price-oracle/test/PriceOracle.test.ts
@@ -194,7 +194,7 @@ describe('PriceOracle', () => {
       })
 
       it('reverts', async () => {
-        await expect(getPrice()).to.be.revertedWith('OracleMissingFeed')
+        await expect(getPrice()).to.be.revertedWith('PriceOracleMissingFeed')
       })
     })
 
@@ -208,7 +208,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
+          await expect(getPrice()).to.be.revertedWith('PriceOracleBaseDecimalsTooBig')
         })
       }
 
@@ -491,7 +491,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
+          await expect(getPrice()).to.be.revertedWith('PriceOracleBaseDecimalsTooBig')
         })
       }
 
@@ -787,7 +787,7 @@ describe('PriceOracle', () => {
         })
 
         it('reverts', async () => {
-          await expect(getPrice()).to.be.revertedWith('BaseDecimalsTooBig')
+          await expect(getPrice()).to.be.revertedWith('PriceOracleBaseDecimalsTooBig')
         })
       }
 
@@ -1591,7 +1591,7 @@ describe('PriceOracle', () => {
 
     const itRevertsDueToMissingFeed = () => {
       it('reverts due to missing feed', async () => {
-        await expect(getPrice()).to.be.revertedWith('OracleMissingFeed')
+        await expect(getPrice()).to.be.revertedWith('PriceOracleMissingFeed')
       })
     }
 
@@ -1633,7 +1633,7 @@ describe('PriceOracle', () => {
 
           const itRevertsDueToOutdatedFeed = () => {
             it('reverts due to outdated feed', async () => {
-              await expect(getPrice()).to.be.revertedWith('OraclePriceOutdated')
+              await expect(getPrice()).to.be.revertedWith('PriceOraclePriceOutdated')
             })
           }
 

--- a/packages/registry/contracts/Registry.sol
+++ b/packages/registry/contracts/Registry.sol
@@ -67,9 +67,9 @@ contract Registry is IRegistry, Ownable {
      * @param implementation Address of the implementation to be deprecated
      */
     function deprecate(address implementation) external override onlyOwner {
-        require(implementation != address(0), 'REGISTRY_IMPL_ADDRESS_ZERO');
-        require(isRegistered[implementation], 'REGISTRY_IMPL_NOT_REGISTERED');
-        require(!isDeprecated[implementation], 'REGISTRY_IMPL_ALREADY_DEPRECATED');
+        if (implementation == address(0)) revert RegistryImplAddressZero();
+        if (!isRegistered[implementation]) revert RegistryImplNotRegistered(implementation);
+        if (isDeprecated[implementation]) revert RegistryImplAlreadyDeprecated(implementation);
 
         isDeprecated[implementation] = true;
         emit Deprecated(implementation);
@@ -82,8 +82,8 @@ contract Registry is IRegistry, Ownable {
      * @param stateless Whether the given implementation is considered stateless or not
      */
     function _register(string memory name, address implementation, bool stateless) internal {
-        require(implementation != address(0), 'REGISTRY_IMPL_ADDRESS_ZERO');
-        require(!isRegistered[implementation], 'REGISTRY_IMPL_ALREADY_REGISTERED');
+        if (implementation == address(0)) revert RegistryImplAddressZero();
+        if (isRegistered[implementation]) revert RegistryImplAlreadyRegistered(implementation);
 
         isRegistered[implementation] = true;
         isStateless[implementation] = stateless;

--- a/packages/registry/contracts/Registry.sol
+++ b/packages/registry/contracts/Registry.sol
@@ -67,9 +67,9 @@ contract Registry is IRegistry, Ownable {
      * @param implementation Address of the implementation to be deprecated
      */
     function deprecate(address implementation) external override onlyOwner {
-        if (implementation == address(0)) revert RegistryImplAddressZero();
-        if (!isRegistered[implementation]) revert RegistryImplNotRegistered(implementation);
-        if (isDeprecated[implementation]) revert RegistryImplAlreadyDeprecated(implementation);
+        if (implementation == address(0)) revert RegistryImplementationAddressZero();
+        if (!isRegistered[implementation]) revert RegistryImplementationNotRegistered(implementation);
+        if (isDeprecated[implementation]) revert RegistryImplementationDeprecated(implementation);
 
         isDeprecated[implementation] = true;
         emit Deprecated(implementation);
@@ -82,8 +82,8 @@ contract Registry is IRegistry, Ownable {
      * @param stateless Whether the given implementation is considered stateless or not
      */
     function _register(string memory name, address implementation, bool stateless) internal {
-        if (implementation == address(0)) revert RegistryImplAddressZero();
-        if (isRegistered[implementation]) revert RegistryImplAlreadyRegistered(implementation);
+        if (implementation == address(0)) revert RegistryImplementationAddressZero();
+        if (isRegistered[implementation]) revert RegistryImplementationRegistered(implementation);
 
         isRegistered[implementation] = true;
         isStateless[implementation] = stateless;

--- a/packages/registry/contracts/interfaces/IRegistry.sol
+++ b/packages/registry/contracts/interfaces/IRegistry.sol
@@ -26,6 +26,11 @@ interface IRegistry {
     error RegistryImplementationAddressZero();
 
     /**
+     * @dev The implementation is already registered
+     */
+    error RegistryImplementationRegistered(address implementation);
+
+    /**
      * @dev The implementation is not registered
      */
     error RegistryImplementationNotRegistered(address implementation);
@@ -34,11 +39,6 @@ interface IRegistry {
      * @dev The implementation is already deprecated
      */
     error RegistryImplementationDeprecated(address implementation);
-
-    /**
-     * @dev The implementation is already registered
-     */
-    error RegistryImplementationRegistered(address implementation);
 
     /**
      * @dev Emitted every time an implementation is registered

--- a/packages/registry/contracts/interfaces/IRegistry.sol
+++ b/packages/registry/contracts/interfaces/IRegistry.sol
@@ -23,22 +23,22 @@ interface IRegistry {
     /**
      * @dev The implementation address is zero
      */
-    error RegistryImplAddressZero();
+    error RegistryImplementationAddressZero();
 
     /**
      * @dev The implementation is not registered
      */
-    error RegistryImplNotRegistered(address implementation);
+    error RegistryImplementationNotRegistered(address implementation);
 
     /**
      * @dev The implementation is already deprecated
      */
-    error RegistryImplAlreadyDeprecated(address implementation);
+    error RegistryImplementationDeprecated(address implementation);
 
     /**
      * @dev The implementation is already registered
      */
-    error RegistryImplAlreadyRegistered(address implementation);
+    error RegistryImplementationRegistered(address implementation);
 
     /**
      * @dev Emitted every time an implementation is registered

--- a/packages/registry/contracts/interfaces/IRegistry.sol
+++ b/packages/registry/contracts/interfaces/IRegistry.sol
@@ -21,6 +21,26 @@ import './IRegistry.sol';
  */
 interface IRegistry {
     /**
+     * @dev The implementation address is zero
+     */
+    error RegistryImplAddressZero();
+
+    /**
+     * @dev The implementation is not registered
+     */
+    error RegistryImplNotRegistered(address implementation);
+
+    /**
+     * @dev The implementation is already deprecated
+     */
+    error RegistryImplAlreadyDeprecated(address implementation);
+
+    /**
+     * @dev The implementation is already registered
+     */
+    error RegistryImplAlreadyRegistered(address implementation);
+
+    /**
      * @dev Emitted every time an implementation is registered
      */
     event Registered(address indexed implementation, string name, bool stateless);

--- a/packages/registry/test/Registry.test.ts
+++ b/packages/registry/test/Registry.test.ts
@@ -82,7 +82,7 @@ describe('Registry', () => {
 
           it('reverts', async () => {
             await expect(registry.register(name, implementation, true)).to.be.revertedWith(
-              'REGISTRY_IMPL_ALREADY_REGISTERED'
+              'RegistryImplAlreadyRegistered'
             )
           })
         })
@@ -155,7 +155,7 @@ describe('Registry', () => {
 
         it('reverts', async () => {
           await expect(registry.register(name, implementation, true)).to.be.revertedWith(
-            'REGISTRY_IMPL_ALREADY_REGISTERED'
+            'RegistryImplAlreadyRegistered'
           )
         })
       })
@@ -182,7 +182,7 @@ describe('Registry', () => {
 
       context('when the requested implementation is not registered', () => {
         it('reverts', async () => {
-          await expect(registry.deprecate(implementation)).to.be.revertedWith('REGISTRY_IMPL_NOT_REGISTERED')
+          await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplNotRegistered')
         })
       })
 
@@ -213,7 +213,7 @@ describe('Registry', () => {
           })
 
           it('reverts', async () => {
-            await expect(registry.deprecate(implementation)).to.be.revertedWith('REGISTRY_IMPL_ALREADY_DEPRECATED')
+            await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplAlreadyDeprecated')
           })
         })
       })

--- a/packages/registry/test/Registry.test.ts
+++ b/packages/registry/test/Registry.test.ts
@@ -82,7 +82,7 @@ describe('Registry', () => {
 
           it('reverts', async () => {
             await expect(registry.register(name, implementation, true)).to.be.revertedWith(
-              'RegistryImplAlreadyRegistered'
+              'RegistryImplementationRegistered'
             )
           })
         })
@@ -155,7 +155,7 @@ describe('Registry', () => {
 
         it('reverts', async () => {
           await expect(registry.register(name, implementation, true)).to.be.revertedWith(
-            'RegistryImplAlreadyRegistered'
+            'RegistryImplementationRegistered'
           )
         })
       })
@@ -182,7 +182,7 @@ describe('Registry', () => {
 
       context('when the requested implementation is not registered', () => {
         it('reverts', async () => {
-          await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplNotRegistered')
+          await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplementationNotRegistered')
         })
       })
 
@@ -213,7 +213,7 @@ describe('Registry', () => {
           })
 
           it('reverts', async () => {
-            await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplAlreadyDeprecated')
+            await expect(registry.deprecate(implementation)).to.be.revertedWith('RegistryImplementationDeprecated')
           })
         })
       })

--- a/packages/relayer/contracts/Relayer.sol
+++ b/packages/relayer/contracts/Relayer.sol
@@ -96,7 +96,7 @@ contract Relayer is IRelayer, Ownable {
      * @param collector Address of the collector to be set for the given smart vault
      */
     function setSmartVaultCollector(address smartVault, address collector) external override onlyOwner {
-        if (collector == address(0)) revert RelayerInputZero();
+        if (collector == address(0)) revert RelayerCollectorZero();
         getSmartVaultCollector[smartVault] = collector;
         emit SmartVaultCollectorSet(smartVault, collector);
     }
@@ -117,7 +117,7 @@ contract Relayer is IRelayer, Ownable {
      * @param amount Amount of native tokens to be deposited, must match msg.value
      */
     function deposit(address smartVault, uint256 amount) external payable override {
-        if (msg.value != amount) revert RelayerDepositInvalidAmount(msg.value, amount);
+        if (msg.value != amount) revert RelayerValueDoesNotMatchAmount(msg.value, amount);
         uint256 amountPaid = _payQuota(smartVault, amount);
         uint256 toDeposit = amount - amountPaid;
         getSmartVaultBalance[smartVault] += toDeposit;
@@ -130,7 +130,7 @@ contract Relayer is IRelayer, Ownable {
      */
     function withdraw(uint256 amount) external override {
         uint256 balance = getSmartVaultBalance[msg.sender];
-        if (amount > balance) revert RelayerWithdrawSvInsufficientBal(amount, balance);
+        if (amount > balance) revert RelayerWithdrawInsufficientBalance(msg.sender, balance, amount);
         getSmartVaultBalance[msg.sender] = balance - amount;
         emit Withdrawn(msg.sender, amount);
         (bool success, ) = payable(msg.sender).call{ value: amount }('');
@@ -153,8 +153,8 @@ contract Relayer is IRelayer, Ownable {
         for (uint256 i = 0; i < tasks.length; i++) {
             uint256 initialGas = gasleft();
             address task = tasks[i];
-            if (ITask(task).smartVault() != smartVault || !ISmartVault(smartVault).hasPermissions(task))
-                revert RelayerInvalidTask(task, smartVault);
+            if (ITask(task).smartVault() != smartVault) revert RelayerInvalidTaskSmartVault(task, smartVault);
+            if (!ISmartVault(smartVault).hasPermissions(task)) revert RelayerInvalidTaskPermissions(task, smartVault);
             bytes memory data = datas[i];
             // solhint-disable-next-line avoid-low-level-calls
             (bool taskSuccess, bytes memory result) = task.call(data);
@@ -176,7 +176,9 @@ contract Relayer is IRelayer, Ownable {
      * @param amount Amount of tokens to withdraw
      */
     function rescueFunds(address token, address recipient, uint256 amount) external override onlyOwner {
-        if (token == address(0) || recipient == address(0) || amount == 0) revert RelayerInputZero();
+        if (token == address(0)) revert RelayerTokenZero();
+        if (recipient == address(0)) revert RelayerRecipientZero();
+        if (amount == 0) revert RelayerAmountZero();
 
         IERC20(token).safeTransfer(recipient, amount);
         emit FundsRescued(token, recipient, amount);
@@ -188,7 +190,7 @@ contract Relayer is IRelayer, Ownable {
      * @param allowed Whether the given executor should be allowed or not
      */
     function _setExecutor(address executor, bool allowed) internal {
-        if (executor == address(0)) revert RelayerInputZero();
+        if (executor == address(0)) revert RelayerExecutorZero();
         isExecutorAllowed[executor] = allowed;
         emit ExecutorSet(executor, allowed);
     }
@@ -198,7 +200,7 @@ contract Relayer is IRelayer, Ownable {
      * @param collector Default fee collector to be set
      */
     function _setDefaultCollector(address collector) internal {
-        if (collector == address(0)) revert RelayerInputZero();
+        if (collector == address(0)) revert RelayerCollectorZero();
         defaultCollector = collector;
         emit DefaultCollectorSet(collector);
     }
@@ -213,7 +215,8 @@ contract Relayer is IRelayer, Ownable {
         uint256 maxQuota = getSmartVaultMaxQuota[smartVault];
         uint256 usedQuota = getSmartVaultUsedQuota[smartVault];
         uint256 availableQuota = usedQuota >= maxQuota ? 0 : (maxQuota - usedQuota);
-        if (amount > balance + availableQuota) revert RelayerPaymentSvInsufficientBal(amount, balance, availableQuota);
+        if (amount > balance + availableQuota)
+            revert RelayerPaymentInsufficientBal(smartVault, balance, availableQuota, amount);
 
         uint256 quota;
         if (balance >= amount) {
@@ -225,7 +228,7 @@ contract Relayer is IRelayer, Ownable {
         }
 
         (bool paySuccess, ) = getApplicableCollector(smartVault).call{ value: amount - quota }('');
-        if (!paySuccess) revert RelayerCollectorFailed(smartVault, amount, quota);
+        if (!paySuccess) revert RelayerPaymentFailed(smartVault, amount, quota);
         emit GasPaid(smartVault, amount, quota);
     }
 

--- a/packages/relayer/contracts/Relayer.sol
+++ b/packages/relayer/contracts/Relayer.sol
@@ -176,8 +176,7 @@ contract Relayer is IRelayer, Ownable {
      * @param amount Amount of tokens to withdraw
      */
     function rescueFunds(address token, address recipient, uint256 amount) external override onlyOwner {
-        if (token == address(0) || recipient == address(0) || amount == 0)
-            revert RelayerInputZero();
+        if (token == address(0) || recipient == address(0) || amount == 0) revert RelayerInputZero();
 
         IERC20(token).safeTransfer(recipient, amount);
         emit FundsRescued(token, recipient, amount);
@@ -214,8 +213,7 @@ contract Relayer is IRelayer, Ownable {
         uint256 maxQuota = getSmartVaultMaxQuota[smartVault];
         uint256 usedQuota = getSmartVaultUsedQuota[smartVault];
         uint256 availableQuota = usedQuota >= maxQuota ? 0 : (maxQuota - usedQuota);
-        if (amount > balance + availableQuota)
-            revert RelayerPaymentSvInsufficientBal(amount, balance, availableQuota);
+        if (amount > balance + availableQuota) revert RelayerPaymentSvInsufficientBal(amount, balance, availableQuota);
 
         uint256 quota;
         if (balance >= amount) {

--- a/packages/relayer/contracts/Relayer.sol
+++ b/packages/relayer/contracts/Relayer.sol
@@ -96,7 +96,7 @@ contract Relayer is IRelayer, Ownable {
      * @param collector Address of the collector to be set for the given smart vault
      */
     function setSmartVaultCollector(address smartVault, address collector) external override onlyOwner {
-        require(collector != address(0), 'RELAYER_COLLECTOR_ZERO');
+        if (collector == address(0)) revert RelayerCollectorZero();
         getSmartVaultCollector[smartVault] = collector;
         emit SmartVaultCollectorSet(smartVault, collector);
     }
@@ -117,7 +117,7 @@ contract Relayer is IRelayer, Ownable {
      * @param amount Amount of native tokens to be deposited, must match msg.value
      */
     function deposit(address smartVault, uint256 amount) external payable override {
-        require(msg.value == amount, 'RELAYER_DEPOSIT_INVALID_AMOUNT');
+        if (msg.value != amount) revert RelayerInvalidAmount(msg.value, amount);
         uint256 amountPaid = _payQuota(smartVault, amount);
         uint256 toDeposit = amount - amountPaid;
         getSmartVaultBalance[smartVault] += toDeposit;
@@ -130,11 +130,11 @@ contract Relayer is IRelayer, Ownable {
      */
     function withdraw(uint256 amount) external override {
         uint256 balance = getSmartVaultBalance[msg.sender];
-        require(amount <= balance, 'RELAYER_SMART_VAULT_NO_BALANCE');
+        if (amount > balance) revert RelayerWithdrawInsufficentBalance(amount, balance);
         getSmartVaultBalance[msg.sender] = balance - amount;
         emit Withdrawn(msg.sender, amount);
         (bool success, ) = payable(msg.sender).call{ value: amount }('');
-        require(success, 'RELAYER_WITHDRAW_FAILED');
+        if (!success) revert RelayerWithdrawFailed(msg.sender, amount);
     }
 
     /**
@@ -144,18 +144,15 @@ contract Relayer is IRelayer, Ownable {
      * @param continueIfFailed Whether the execution should fail in case one of the tasks fail
      */
     function execute(address[] memory tasks, bytes[] memory datas, bool continueIfFailed) external override {
-        require(isExecutorAllowed[msg.sender], 'RELAYER_EXECUTOR_NOT_ALLOWED');
-        require(tasks.length > 0, 'RELAYER_EXECUTE_NO_INPUT');
-        require(tasks.length == datas.length, 'RELAYER_EXECUTE_INPUT_BAD_LENGTH');
+        if (!isExecutorAllowed[msg.sender]) revert RelayerExecutorNotAllowed(msg.sender);
+        if (tasks.length == 0 || tasks.length != datas.length) revert RelayerExecuteInputBadLength(tasks.length, datas.length);
 
         uint256 totalGasUsed = BASE_GAS;
         address smartVault = ITask(tasks[0]).smartVault();
         for (uint256 i = 0; i < tasks.length; i++) {
             uint256 initialGas = gasleft();
             address task = tasks[i];
-            require(ITask(task).smartVault() == smartVault, 'RELAYER_INVALID_TASK_SMART_VAULT');
-            require(ISmartVault(smartVault).hasPermissions(task), 'RELAYER_INVALID_TASK_PERMISSIONS');
-
+            if (ITask(task).smartVault() != smartVault || !ISmartVault(smartVault).hasPermissions(task)) revert RelayerInvalidTask(task, smartVault);
             bytes memory data = datas[i];
             // solhint-disable-next-line avoid-low-level-calls
             (bool taskSuccess, bytes memory result) = task.call(data);
@@ -177,9 +174,9 @@ contract Relayer is IRelayer, Ownable {
      * @param amount Amount of tokens to withdraw
      */
     function rescueFunds(address token, address recipient, uint256 amount) external override onlyOwner {
-        require(token != address(0), 'RELAYER_EXT_WITHDRAW_TOKEN_ZERO');
-        require(recipient != address(0), 'RELAYER_EXT_WITHDRAW_DEST_ZERO');
-        require(amount > 0, 'RELAYER_EXT_WITHDRAW_AMOUNT_ZERO');
+        if (token == address(0)) revert RelayerTokenZero();
+        if (recipient == address(0)) revert RelayerRecipientZero();
+        if (amount == 0) revert RelayerAmountZero();
 
         IERC20(token).safeTransfer(recipient, amount);
         emit FundsRescued(token, recipient, amount);
@@ -191,7 +188,7 @@ contract Relayer is IRelayer, Ownable {
      * @param allowed Whether the given executor should be allowed or not
      */
     function _setExecutor(address executor, bool allowed) internal {
-        require(executor != address(0), 'RELAYER_EXECUTOR_ZERO');
+        if (executor == address(0)) revert RelayerExecutorZero();
         isExecutorAllowed[executor] = allowed;
         emit ExecutorSet(executor, allowed);
     }
@@ -201,7 +198,7 @@ contract Relayer is IRelayer, Ownable {
      * @param collector Default fee collector to be set
      */
     function _setDefaultCollector(address collector) internal {
-        require(collector != address(0), 'RELAYER_COLLECTOR_ZERO');
+        if (collector == address(0)) revert RelayerCollectorZero();
         defaultCollector = collector;
         emit DefaultCollectorSet(collector);
     }
@@ -216,7 +213,7 @@ contract Relayer is IRelayer, Ownable {
         uint256 maxQuota = getSmartVaultMaxQuota[smartVault];
         uint256 usedQuota = getSmartVaultUsedQuota[smartVault];
         uint256 availableQuota = usedQuota >= maxQuota ? 0 : (maxQuota - usedQuota);
-        require(amount <= balance + availableQuota, 'RELAYER_SMART_VAULT_NO_BALANCE');
+        if (amount <= balance + availableQuota) revert RelayerPaymentSvInsufficentBalance(amount, balance, availableQuota);
 
         uint256 quota;
         if (balance >= amount) {
@@ -228,7 +225,7 @@ contract Relayer is IRelayer, Ownable {
         }
 
         (bool paySuccess, ) = getApplicableCollector(smartVault).call{ value: amount - quota }('');
-        require(paySuccess, 'RELAYER_COLLECTOR_SEND_FAILED');
+        if (!paySuccess) revert RelayerCollectorFailed(smartVault, amount, quota);
         emit GasPaid(smartVault, amount, quota);
     }
 

--- a/packages/relayer/contracts/interfaces/IRelayer.sol
+++ b/packages/relayer/contracts/interfaces/IRelayer.sol
@@ -19,19 +19,19 @@ pragma solidity >=0.8.0;
  */
 interface IRelayer {
     /**
-     * @dev The collector address is zero
+     * @dev The parameter is zero
      */
-    error RelayerCollectorZero();
+    error RelayerInputZero();
 
     /**
      * @dev The value sent and the amount differ
      */
-    error RelayerInvalidAmount(uint256 value, uint256 amount);
+    error RelayerDepositInvalidAmount(uint256 value, uint256 amount);
 
     /**
      * @dev The smart vault balance is lower than the amount to withdraw
      */
-    error RelayerWithdrawSvInsufficentBalance(uint256 amount, uint256 balance);
+    error RelayerWithdrawSvInsufficientBal(uint256 amount, uint256 balance);
 
     /**
      * @dev It failed to send the amount to the sender
@@ -54,29 +54,9 @@ interface IRelayer {
     error RelayerInvalidTask(address task, address smartVault);
 
     /**
-     * @dev The token is zero
-     */
-    error RelayerTokenZero();
-
-    /**
-     * @dev The recipient is zero
-     */
-    error RelayerRecipientZero();
-
-    /**
-     * @dev The amount is zero
-     */
-    error RelayerAmountZero();
-
-    /**
-     * @dev The executor is zero
-     */
-    error RelayerExecutorZero();
-
-    /**
      * @dev The smart vault balance plus the available quota are lower than the amount to pay the relayer
      */
-    error RelayerPaymentSvInsufficentBalance(uint256 amount, uint256 balance, uint256 availableQuota);
+    error RelayerPaymentSvInsufficientBal(uint256 amount, uint256 balance, uint256 availableQuota);
 
     /**
      * @dev It failed to send amount minus quota to the smart vault's collector

--- a/packages/relayer/contracts/interfaces/IRelayer.sol
+++ b/packages/relayer/contracts/interfaces/IRelayer.sol
@@ -19,19 +19,39 @@ pragma solidity >=0.8.0;
  */
 interface IRelayer {
     /**
-     * @dev The parameter is zero
+     * @dev The collector is zero
      */
-    error RelayerInputZero();
+    error RelayerCollectorZero();
+
+    /**
+     * @dev The token is zero
+     */
+    error RelayerTokenZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error RelayerRecipientZero();
+
+    /**
+     * @dev The amount is zero
+     */
+    error RelayerAmountZero();
+
+    /**
+     * @dev The executor is zero
+     */
+    error RelayerExecutorZero();
 
     /**
      * @dev The value sent and the amount differ
      */
-    error RelayerDepositInvalidAmount(uint256 value, uint256 amount);
+    error RelayerValueDoesNotMatchAmount(uint256 value, uint256 amount);
 
     /**
      * @dev The smart vault balance is lower than the amount to withdraw
      */
-    error RelayerWithdrawSvInsufficientBal(uint256 amount, uint256 balance);
+    error RelayerWithdrawInsufficientBalance(address sender, uint256 balance, uint256 amount);
 
     /**
      * @dev It failed to send the amount to the sender
@@ -49,19 +69,24 @@ interface IRelayer {
     error RelayerExecuteInputBadLength(uint256 tasksLength, uint256 datasLength);
 
     /**
-     * @dev The task's smart vault is wrong or the smart vault is not allowed to execute the task
+     * @dev The task's smart vault is wrong
      */
-    error RelayerInvalidTask(address task, address smartVault);
+    error RelayerInvalidTaskSmartVault(address task, address smartVault);
+
+    /**
+     * @dev The smart vault is not allowed to execute the task
+     */
+    error RelayerInvalidTaskPermissions(address task, address smartVault);
 
     /**
      * @dev The smart vault balance plus the available quota are lower than the amount to pay the relayer
      */
-    error RelayerPaymentSvInsufficientBal(uint256 amount, uint256 balance, uint256 availableQuota);
+    error RelayerPaymentInsufficientBal(address smartVault, uint256 balance, uint256 availableQuota, uint256 amount);
 
     /**
      * @dev It failed to send amount minus quota to the smart vault's collector
      */
-    error RelayerCollectorFailed(address smartVault, uint256 amount, uint256 quota);
+    error RelayerPaymentFailed(address smartVault, uint256 amount, uint256 quota);
 
     /**
      * @dev Emitted every time an executor is configured

--- a/packages/relayer/contracts/interfaces/IRelayer.sol
+++ b/packages/relayer/contracts/interfaces/IRelayer.sol
@@ -81,7 +81,7 @@ interface IRelayer {
     /**
      * @dev It failed to send amount minus quota to the smart vault's collector
      */
-    error RelayerCollectorFailed(address indexed smartVault, uint256 amount, uint256 quota);
+    error RelayerCollectorFailed(address smartVault, uint256 amount, uint256 quota);
 
     /**
      * @dev Emitted every time an executor is configured

--- a/packages/relayer/contracts/interfaces/IRelayer.sol
+++ b/packages/relayer/contracts/interfaces/IRelayer.sol
@@ -19,6 +19,71 @@ pragma solidity >=0.8.0;
  */
 interface IRelayer {
     /**
+     * @dev The collector address is zero
+     */
+    error RelayerCollectorZero();
+
+    /**
+     * @dev The value sent and the amount differ
+     */
+    error RelayerInvalidAmount(uint256 value, uint256 amount);
+
+    /**
+     * @dev The smart vault balance is lower than the amount to withdraw
+     */
+    error RelayerWithdrawSvInsufficentBalance(uint256 amount, uint256 balance);
+
+    /**
+     * @dev It failed to send the amount to the sender
+     */
+    error RelayerWithdrawFailed(address sender, uint256 amount);
+
+    /**
+     * @dev The sender is not allowed
+     */
+    error RelayerExecutorNotAllowed(address sender);
+
+    /**
+     * @dev Empty tasks array or a mismatch between the parameters length for an execution
+     */
+    error RelayerExecuteInputBadLength(uint256 tasksLength, uint256 datasLength);
+
+    /**
+     * @dev The task's smart vault is wrong or the smart vault is not allowed to execute the task
+     */
+    error RelayerInvalidTask(address task, address smartVault);
+
+    /**
+     * @dev The token is zero
+     */
+    error RelayerTokenZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error RelayerRecipientZero();
+
+    /**
+     * @dev The amount is zero
+     */
+    error RelayerAmountZero();
+
+    /**
+     * @dev The executor is zero
+     */
+    error RelayerExecutorZero();
+
+    /**
+     * @dev The smart vault balance plus the available quota are lower than the amount to pay the relayer
+     */
+    error RelayerPaymentSvInsufficentBalance(uint256 amount, uint256 balance, uint256 availableQuota);
+
+    /**
+     * @dev It failed to send amount minus quota to the smart vault's collector
+     */
+    error RelayerCollectorFailed(address indexed smartVault, uint256 amount, uint256 quota);
+
+    /**
      * @dev Emitted every time an executor is configured
      */
     event ExecutorSet(address indexed executor, bool allowed);

--- a/packages/relayer/contracts/interfaces/IRelayer.sol
+++ b/packages/relayer/contracts/interfaces/IRelayer.sol
@@ -19,19 +19,9 @@ pragma solidity >=0.8.0;
  */
 interface IRelayer {
     /**
-     * @dev The collector is zero
-     */
-    error RelayerCollectorZero();
-
-    /**
      * @dev The token is zero
      */
     error RelayerTokenZero();
-
-    /**
-     * @dev The recipient is zero
-     */
-    error RelayerRecipientZero();
 
     /**
      * @dev The amount is zero
@@ -39,14 +29,54 @@ interface IRelayer {
     error RelayerAmountZero();
 
     /**
+     * @dev The collector is zero
+     */
+    error RelayerCollectorZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error RelayerRecipientZero();
+
+    /**
      * @dev The executor is zero
      */
     error RelayerExecutorZero();
 
     /**
-     * @dev The value sent and the amount differ
+     * @dev Relayer no task given to execute
      */
-    error RelayerValueDoesNotMatchAmount(uint256 value, uint256 amount);
+    error RelayerNoTaskGiven();
+
+    /**
+     * @dev Relayer input length mismatch
+     */
+    error RelayerInputLengthMismatch();
+
+    /**
+     * @dev The sender is not allowed
+     */
+    error RelayerExecutorNotAllowed(address sender);
+
+    /**
+     * @dev Trying to execute tasks from different smart vaults
+     */
+    error RelayerMultipleTaskSmartVaults(address task, address taskSmartVault, address expectedSmartVault);
+
+    /**
+     * @dev The task to execute does not have permissions on the associated smart vault
+     */
+    error RelayerTaskDoesNotHavePermissions(address task, address smartVault);
+
+    /**
+     * @dev The smart vault balance plus the available quota are lower than the amount to pay the relayer
+     */
+    error RelayerPaymentInsufficientBalance(address smartVault, uint256 balance, uint256 quota, uint256 amount);
+
+    /**
+     * @dev It failed to send amount minus quota to the smart vault's collector
+     */
+    error RelayerPaymentFailed(address smartVault, uint256 amount, uint256 quota);
 
     /**
      * @dev The smart vault balance is lower than the amount to withdraw
@@ -59,34 +89,9 @@ interface IRelayer {
     error RelayerWithdrawFailed(address sender, uint256 amount);
 
     /**
-     * @dev The sender is not allowed
+     * @dev The value sent and the amount differ
      */
-    error RelayerExecutorNotAllowed(address sender);
-
-    /**
-     * @dev Empty tasks array or a mismatch between the parameters length for an execution
-     */
-    error RelayerExecuteInputBadLength(uint256 tasksLength, uint256 datasLength);
-
-    /**
-     * @dev The task's smart vault is wrong
-     */
-    error RelayerInvalidTaskSmartVault(address task, address smartVault);
-
-    /**
-     * @dev The smart vault is not allowed to execute the task
-     */
-    error RelayerInvalidTaskPermissions(address task, address smartVault);
-
-    /**
-     * @dev The smart vault balance plus the available quota are lower than the amount to pay the relayer
-     */
-    error RelayerPaymentInsufficientBal(address smartVault, uint256 balance, uint256 availableQuota, uint256 amount);
-
-    /**
-     * @dev It failed to send amount minus quota to the smart vault's collector
-     */
-    error RelayerPaymentFailed(address smartVault, uint256 amount, uint256 quota);
+    error RelayerValueDoesNotMatchAmount(uint256 value, uint256 amount);
 
     /**
      * @dev Emitted every time an executor is configured
@@ -229,10 +234,10 @@ interface IRelayer {
     /**
      * @dev Executes a list of tasks
      * @param tasks Addresses of the tasks to execute
-     * @param datas List of calldata to execute each of the given tasks
+     * @param data List of calldata to execute each of the given tasks
      * @param continueIfFailed Whether the execution should fail in case one of the tasks fail
      */
-    function execute(address[] memory tasks, bytes[] memory datas, bool continueIfFailed) external;
+    function execute(address[] memory tasks, bytes[] memory data, bool continueIfFailed) external;
 
     /**
      * @dev Withdraw ERC20 tokens to an external account. To be used in case of accidental token transfers.

--- a/packages/relayer/test/Relayer.test.ts
+++ b/packages/relayer/test/Relayer.test.ts
@@ -658,7 +658,7 @@ describe('Relayer', () => {
           context('when the available quota is not enough', () => {
             it('reverts', async () => {
               await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-                'RelayerPaymentInsufficientBal'
+                'RelayerPaymentInsufficientBalance'
               )
             })
           })
@@ -668,7 +668,7 @@ describe('Relayer', () => {
       context('when the task does not have permissions over the associated smart vault', () => {
         it('reverts', async () => {
           await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-            'RelayerInvalidTaskPermissions'
+            'RelayerTaskDoesNotHavePermissions'
           )
         })
       })

--- a/packages/relayer/test/Relayer.test.ts
+++ b/packages/relayer/test/Relayer.test.ts
@@ -18,6 +18,8 @@ import { BigNumber, Contract } from 'ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 import { ethers } from 'hardhat'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('Relayer', () => {
   let relayer: Contract
   let executor: SignerWithAddress, collector: SignerWithAddress, owner: SignerWithAddress
@@ -665,9 +667,7 @@ describe('Relayer', () => {
 
       context('when the task does not have permissions over the associated smart vault', () => {
         it('reverts', async () => {
-          await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-            'RelayerInvalidTask'
-          )
+          await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith('RelayerInvalidTask')
         })
       })
     })
@@ -788,9 +788,7 @@ describe('Relayer', () => {
       context('when the token is the zero address', () => {
         const tokenAddr = ZERO_ADDRESS
         it('reverts', async () => {
-          await expect(relayer.rescueFunds(tokenAddr, recipient.address, amount)).to.be.revertedWith(
-            'RelayerInputZero'
-          )
+          await expect(relayer.rescueFunds(tokenAddr, recipient.address, amount)).to.be.revertedWith('RelayerInputZero')
         })
       })
     })

--- a/packages/relayer/test/Relayer.test.ts
+++ b/packages/relayer/test/Relayer.test.ts
@@ -112,7 +112,7 @@ describe('Relayer', () => {
         const collector = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(relayer.setDefaultCollector(collector)).to.be.revertedWith('RelayerInputZero')
+          await expect(relayer.setDefaultCollector(collector)).to.be.revertedWith('RelayerCollectorZero')
         })
       })
     })
@@ -154,7 +154,7 @@ describe('Relayer', () => {
 
         it('reverts', async () => {
           await expect(relayer.setSmartVaultCollector(smartVault.address, collector)).to.be.revertedWith(
-            'RelayerInputZero'
+            'RelayerCollectorZero'
           )
         })
       })
@@ -354,7 +354,7 @@ describe('Relayer', () => {
 
       it('reverts', async () => {
         await expect(relayer.deposit(smartVault.address, amount, { value })).to.revertedWith(
-          'RelayerDepositInvalidAmount'
+          'RelayerValueDoesNotMatchAmount'
         )
       })
     })
@@ -413,7 +413,7 @@ describe('Relayer', () => {
       const amount = balance.add(1)
 
       it('reverts', async () => {
-        await expect(relayer.connect(smartVault).withdraw(amount)).to.revertedWith('RelayerWithdrawSvInsufficientBal')
+        await expect(relayer.connect(smartVault).withdraw(amount)).to.revertedWith('RelayerWithdrawInsufficientBalance')
       })
     })
   })
@@ -658,7 +658,7 @@ describe('Relayer', () => {
           context('when the available quota is not enough', () => {
             it('reverts', async () => {
               await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-                'RelayerPaymentSvInsufficientBal'
+                'RelayerPaymentInsufficientBal'
               )
             })
           })
@@ -667,7 +667,9 @@ describe('Relayer', () => {
 
       context('when the task does not have permissions over the associated smart vault', () => {
         it('reverts', async () => {
-          await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith('RelayerInvalidTask')
+          await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
+            'RelayerInvalidTaskPermissions'
+          )
         })
       })
     })
@@ -769,7 +771,7 @@ describe('Relayer', () => {
             const amount = 0
             it('reverts', async () => {
               await expect(relayer.rescueFunds(token.address, recipient.address, amount)).to.be.revertedWith(
-                'RelayerInputZero'
+                'RelayerAmountZero'
               )
             })
           })
@@ -779,7 +781,7 @@ describe('Relayer', () => {
           const recipientAddr = ZERO_ADDRESS
           it('reverts', async () => {
             await expect(relayer.rescueFunds(token.address, recipientAddr, amount)).to.be.revertedWith(
-              'RelayerInputZero'
+              'RelayerRecipientZero'
             )
           })
         })
@@ -788,7 +790,7 @@ describe('Relayer', () => {
       context('when the token is the zero address', () => {
         const tokenAddr = ZERO_ADDRESS
         it('reverts', async () => {
-          await expect(relayer.rescueFunds(tokenAddr, recipient.address, amount)).to.be.revertedWith('RelayerInputZero')
+          await expect(relayer.rescueFunds(tokenAddr, recipient.address, amount)).to.be.revertedWith('RelayerTokenZero')
         })
       })
     })

--- a/packages/relayer/test/Relayer.test.ts
+++ b/packages/relayer/test/Relayer.test.ts
@@ -110,7 +110,7 @@ describe('Relayer', () => {
         const collector = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(relayer.setDefaultCollector(collector)).to.be.revertedWith('RELAYER_COLLECTOR_ZERO')
+          await expect(relayer.setDefaultCollector(collector)).to.be.revertedWith('RelayerInputZero')
         })
       })
     })
@@ -152,7 +152,7 @@ describe('Relayer', () => {
 
         it('reverts', async () => {
           await expect(relayer.setSmartVaultCollector(smartVault.address, collector)).to.be.revertedWith(
-            'RELAYER_COLLECTOR_ZERO'
+            'RelayerInputZero'
           )
         })
       })
@@ -352,7 +352,7 @@ describe('Relayer', () => {
 
       it('reverts', async () => {
         await expect(relayer.deposit(smartVault.address, amount, { value })).to.revertedWith(
-          'RELAYER_DEPOSIT_INVALID_AMOUNT'
+          'RelayerDepositInvalidAmount'
         )
       })
     })
@@ -411,7 +411,7 @@ describe('Relayer', () => {
       const amount = balance.add(1)
 
       it('reverts', async () => {
-        await expect(relayer.connect(smartVault).withdraw(amount)).to.revertedWith('RELAYER_SMART_VAULT_NO_BALANCE')
+        await expect(relayer.connect(smartVault).withdraw(amount)).to.revertedWith('RelayerWithdrawSvInsufficientBal')
       })
     })
   })
@@ -656,7 +656,7 @@ describe('Relayer', () => {
           context('when the available quota is not enough', () => {
             it('reverts', async () => {
               await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-                'RELAYER_SMART_VAULT_NO_BALANCE'
+                'RelayerPaymentSvInsufficientBal'
               )
             })
           })
@@ -666,7 +666,7 @@ describe('Relayer', () => {
       context('when the task does not have permissions over the associated smart vault', () => {
         it('reverts', async () => {
           await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith(
-            'RELAYER_INVALID_TASK_PERMISSIONS'
+            'RelayerInvalidTask'
           )
         })
       })
@@ -674,7 +674,7 @@ describe('Relayer', () => {
 
     context('when the sender is not an executor', () => {
       it('reverts', async () => {
-        await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith('RELAYER_EXECUTOR_NOT_ALLOWED')
+        await expect(relayer.execute([task.address], ['0x'], false)).to.be.revertedWith('RelayerExecutorNotAllowed')
       })
     })
   })
@@ -769,7 +769,7 @@ describe('Relayer', () => {
             const amount = 0
             it('reverts', async () => {
               await expect(relayer.rescueFunds(token.address, recipient.address, amount)).to.be.revertedWith(
-                'RELAYER_EXT_WITHDRAW_AMOUNT_ZERO'
+                'RelayerInputZero'
               )
             })
           })
@@ -779,7 +779,7 @@ describe('Relayer', () => {
           const recipientAddr = ZERO_ADDRESS
           it('reverts', async () => {
             await expect(relayer.rescueFunds(token.address, recipientAddr, amount)).to.be.revertedWith(
-              'RELAYER_EXT_WITHDRAW_DEST_ZERO'
+              'RelayerInputZero'
             )
           })
         })
@@ -789,7 +789,7 @@ describe('Relayer', () => {
         const tokenAddr = ZERO_ADDRESS
         it('reverts', async () => {
           await expect(relayer.rescueFunds(tokenAddr, recipient.address, amount)).to.be.revertedWith(
-            'RELAYER_EXT_WITHDRAW_TOKEN_ZERO'
+            'RelayerInputZero'
           )
         })
       })

--- a/packages/smart-vault/contracts/SmartVault.sol
+++ b/packages/smart-vault/contracts/SmartVault.sol
@@ -134,7 +134,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
      * @dev Unpauses a samrt vault. Sender must be authorized.
      */
     function unpause() external override auth {
-        if (!isPaused) revert SmartVaultAlreadyPaused(address(this));
+        if (!isPaused) revert SmartVaultAlreadyUnpaused(address(this));
         isPaused = false;
         emit Unpaused();
     }
@@ -183,8 +183,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
         notPaused
         authP(authParams(id, token, amount, add))
     {
-        if (id == bytes32(0)) revert SmartVaultConnectorIdZero(address(this));
-        if (token == address(0)) revert SmartVaultConnectorTokenZero(address(this));
+        if (id == bytes32(0) || token == address(0)) revert SmartVaultConnectorInputZero(address(this));
         (add ? _increaseBalanceConnector : _decreaseBalanceConnector)(id, token, amount);
     }
 
@@ -233,7 +232,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
     function wrap(uint256 amount) external override nonReentrant notPaused authP(authParams(amount)) {
         if (amount == 0) revert SmartVaultAmountZero(address(this));
         uint256 balance = address(this).balance;
-        if (balance < amount) revert SmartVaultInsufficentBalance(address(this), balance, amount);
+        if (balance < amount) revert SmartVaultInsufficientBalance(address(this), balance, amount);
         IWrappedNativeToken(wrappedNativeToken).deposit{ value: amount }();
         emit Wrapped(amount);
     }
@@ -330,7 +329,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
      */
     function _decreaseBalanceConnector(bytes32 id, address token, uint256 amount) internal {
         uint256 value = getBalanceConnector[id][token];
-        if (value < amount) revert SmartVaultConnectorInsufficentBalance(address(this), id, token, value, amount);
+        if (value < amount) revert SmartVaultConnectorInsuffBalance(address(this), id, token, value, amount);
         getBalanceConnector[id][token] = value - amount;
         emit BalanceConnectorUpdated(id, token, amount, false);
     }

--- a/packages/smart-vault/contracts/SmartVault.sol
+++ b/packages/smart-vault/contracts/SmartVault.sol
@@ -125,13 +125,13 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
      * @dev Pauses a smart vault. Sender must be authorized.
      */
     function pause() external override auth {
-        if (isPaused) revert SmartVaultAlreadyPaused();
+        if (isPaused) revert SmartVaultPaused();
         isPaused = true;
         emit Paused();
     }
 
     /**
-     * @dev Unpauses a samrt vault. Sender must be authorized.
+     * @dev Unpauses a smart vault. Sender must be authorized.
      */
     function unpause() external override auth {
         if (!isPaused) revert SmartVaultUnpaused();
@@ -183,8 +183,8 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
         notPaused
         authP(authParams(id, token, amount, add))
     {
-        if (id == bytes32(0)) revert SmartVaultConnectorIdZero();
-        if (token == address(0)) revert SmartVaultConnectorTokenZero();
+        if (id == bytes32(0)) revert SmartVaultBalanceConnectorIdZero();
+        if (token == address(0)) revert SmartVaultTokenZero();
         (add ? _increaseBalanceConnector : _decreaseBalanceConnector)(id, token, amount);
     }
 
@@ -233,7 +233,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
     function wrap(uint256 amount) external override nonReentrant notPaused authP(authParams(amount)) {
         if (amount == 0) revert SmartVaultAmountZero();
         uint256 balance = address(this).balance;
-        if (balance < amount) revert SmartVaultInsufficientBalance(balance, amount);
+        if (balance < amount) revert SmartVaultInsufficientNativeTokenBalance(balance, amount);
         IWrappedNativeToken(wrappedNativeToken).deposit{ value: amount }();
         emit Wrapped(amount);
     }
@@ -330,7 +330,7 @@ contract SmartVault is ISmartVault, Authorized, ReentrancyGuardUpgradeable {
      */
     function _decreaseBalanceConnector(bytes32 id, address token, uint256 amount) internal {
         uint256 value = getBalanceConnector[id][token];
-        if (value < amount) revert SmartVaultConnectorInsuffBalance(id, token, value, amount);
+        if (value < amount) revert SmartVaultBalanceConnectorInsufficientBalance(id, token, value, amount);
         getBalanceConnector[id][token] = value - amount;
         emit BalanceConnectorUpdated(id, token, amount, false);
     }

--- a/packages/smart-vault/contracts/interfaces/ISmartVault.sol
+++ b/packages/smart-vault/contracts/interfaces/ISmartVault.sol
@@ -26,14 +26,14 @@ interface ISmartVault is IAuthorized {
     error SmartVaultPaused();
 
     /**
-     * @dev The smart vault is already paused
-     */
-    error SmartVaultAlreadyPaused();
-
-    /**
      * @dev The smart vault is unpaused
      */
     error SmartVaultUnpaused();
+
+    /**
+     * @dev The token is zero
+     */
+    error SmartVaultTokenZero();
 
     /**
      * @dev The amount is zero
@@ -41,29 +41,14 @@ interface ISmartVault is IAuthorized {
     error SmartVaultAmountZero();
 
     /**
-     * @dev The smart vault balance is lower than the amount
-     */
-    error SmartVaultInsufficientBalance(uint256 balance, uint256 amount);
-
-    /**
      * @dev The recipient is zero
      */
     error SmartVaultRecipientZero();
 
     /**
-     * @dev The connector balance is lower than the amount
+     * @dev The connector is deprecated
      */
-    error SmartVaultConnectorInsuffBalance(bytes32 id, address token, uint256 balance, uint256 amount);
-
-    /**
-     * @dev The connector ID is zero
-     */
-    error SmartVaultConnectorIdZero();
-
-    /**
-     * @dev The connector token is zero
-     */
-    error SmartVaultConnectorTokenZero();
+    error SmartVaultConnectorDeprecated(address connector);
 
     /**
      * @dev The connector is not registered
@@ -76,9 +61,19 @@ interface ISmartVault is IAuthorized {
     error SmartVaultConnectorNotStateless(address connector);
 
     /**
-     * @dev The connector is deprecated
+     * @dev The connector ID is zero
      */
-    error SmartVaultConnectorDeprecated(address connector);
+    error SmartVaultBalanceConnectorIdZero();
+
+    /**
+     * @dev The balance connector's balance is lower than the requested amount to be deducted
+     */
+    error SmartVaultBalanceConnectorInsufficientBalance(bytes32 id, address token, uint256 balance, uint256 amount);
+
+    /**
+     * @dev The smart vault's native token balance is lower than the requested amount to be deducted
+     */
+    error SmartVaultInsufficientNativeTokenBalance(uint256 balance, uint256 amount);
 
     /**
      * @dev Emitted every time a smart vault is paused

--- a/packages/smart-vault/contracts/interfaces/ISmartVault.sol
+++ b/packages/smart-vault/contracts/interfaces/ISmartVault.sol
@@ -21,6 +21,51 @@ import '@mimic-fi/v3-authorizer/contracts/interfaces/IAuthorized.sol';
  */
 interface ISmartVault is IAuthorized {
     /**
+     * @dev The smart vault is paused
+     */
+    error SmartVaultPaused(address smartVault);
+
+    /**
+     * @dev The smart vault is already paused
+     */
+    error SmartVaultAlreadyPaused(address smartVault);
+
+    /**
+     * @dev The connector ID is zero
+     */
+    error SmartVaultConnectorIdZero(address smartVault);
+
+    /**
+     * @dev The connector token is zero
+     */
+    error SmartVaultConnectorTokenZero(address smartVault);
+
+    /**
+     * @dev The amount is zero
+     */
+    error SmartVaultAmountZero(address smartVault);
+
+    /**
+     * @dev The smart vault balance is lower than the amount
+     */
+    error SmartVaultInsufficentBalance(address smartVault, uint256 balance, uint256 amount);
+
+    /**
+     * @dev The recipient is zero
+     */
+    error SmartVaultRecipientZero(address smartVault);
+
+    /**
+     * @dev The connector balance is lower than the amount
+     */
+    error SmartVaultConnectorInsufficentBalance(address smartVault, bytes32 id, address token, uint256 balance, uint256 amount);
+
+    /**
+     * @dev The connector is either not registered, non stateless or deprecated
+     */
+    error SmartVaultInvalidConnector(address smartVault, address connector);
+
+    /**
      * @dev Emitted every time a smart vault is paused
      */
     event Paused();

--- a/packages/smart-vault/contracts/interfaces/ISmartVault.sol
+++ b/packages/smart-vault/contracts/interfaces/ISmartVault.sol
@@ -58,7 +58,13 @@ interface ISmartVault is IAuthorized {
     /**
      * @dev The connector balance is lower than the amount
      */
-    error SmartVaultConnectorInsufficentBalance(address smartVault, bytes32 id, address token, uint256 balance, uint256 amount);
+    error SmartVaultConnectorInsufficentBalance(
+        address smartVault,
+        bytes32 id,
+        address token,
+        uint256 balance,
+        uint256 amount
+    );
 
     /**
      * @dev The connector is either not registered, non stateless or deprecated

--- a/packages/smart-vault/contracts/interfaces/ISmartVault.sol
+++ b/packages/smart-vault/contracts/interfaces/ISmartVault.sol
@@ -31,14 +31,14 @@ interface ISmartVault is IAuthorized {
     error SmartVaultAlreadyPaused(address smartVault);
 
     /**
-     * @dev The connector ID is zero
+     * @dev The smart vault is already unpaused
      */
-    error SmartVaultConnectorIdZero(address smartVault);
+    error SmartVaultAlreadyUnpaused(address smartVault);
 
     /**
-     * @dev The connector token is zero
+     * @dev The connector token or ID is zero
      */
-    error SmartVaultConnectorTokenZero(address smartVault);
+    error SmartVaultConnectorInputZero(address smartVault);
 
     /**
      * @dev The amount is zero
@@ -48,7 +48,7 @@ interface ISmartVault is IAuthorized {
     /**
      * @dev The smart vault balance is lower than the amount
      */
-    error SmartVaultInsufficentBalance(address smartVault, uint256 balance, uint256 amount);
+    error SmartVaultInsufficientBalance(address smartVault, uint256 balance, uint256 amount);
 
     /**
      * @dev The recipient is zero
@@ -58,7 +58,7 @@ interface ISmartVault is IAuthorized {
     /**
      * @dev The connector balance is lower than the amount
      */
-    error SmartVaultConnectorInsufficentBalance(
+    error SmartVaultConnectorInsuffBalance(
         address smartVault,
         bytes32 id,
         address token,

--- a/packages/smart-vault/contracts/interfaces/ISmartVault.sol
+++ b/packages/smart-vault/contracts/interfaces/ISmartVault.sol
@@ -23,53 +23,62 @@ interface ISmartVault is IAuthorized {
     /**
      * @dev The smart vault is paused
      */
-    error SmartVaultPaused(address smartVault);
+    error SmartVaultPaused();
 
     /**
      * @dev The smart vault is already paused
      */
-    error SmartVaultAlreadyPaused(address smartVault);
+    error SmartVaultAlreadyPaused();
 
     /**
-     * @dev The smart vault is already unpaused
+     * @dev The smart vault is unpaused
      */
-    error SmartVaultAlreadyUnpaused(address smartVault);
-
-    /**
-     * @dev The connector token or ID is zero
-     */
-    error SmartVaultConnectorInputZero(address smartVault);
+    error SmartVaultUnpaused();
 
     /**
      * @dev The amount is zero
      */
-    error SmartVaultAmountZero(address smartVault);
+    error SmartVaultAmountZero();
 
     /**
      * @dev The smart vault balance is lower than the amount
      */
-    error SmartVaultInsufficientBalance(address smartVault, uint256 balance, uint256 amount);
+    error SmartVaultInsufficientBalance(uint256 balance, uint256 amount);
 
     /**
      * @dev The recipient is zero
      */
-    error SmartVaultRecipientZero(address smartVault);
+    error SmartVaultRecipientZero();
 
     /**
      * @dev The connector balance is lower than the amount
      */
-    error SmartVaultConnectorInsuffBalance(
-        address smartVault,
-        bytes32 id,
-        address token,
-        uint256 balance,
-        uint256 amount
-    );
+    error SmartVaultConnectorInsuffBalance(bytes32 id, address token, uint256 balance, uint256 amount);
 
     /**
-     * @dev The connector is either not registered, non stateless or deprecated
+     * @dev The connector ID is zero
      */
-    error SmartVaultInvalidConnector(address smartVault, address connector);
+    error SmartVaultConnectorIdZero();
+
+    /**
+     * @dev The connector token is zero
+     */
+    error SmartVaultConnectorTokenZero();
+
+    /**
+     * @dev The connector is not registered
+     */
+    error SmartVaultConnectorNotRegistered(address connector);
+
+    /**
+     * @dev The connector is not stateless
+     */
+    error SmartVaultConnectorNotStateless(address connector);
+
+    /**
+     * @dev The connector is deprecated
+     */
+    error SmartVaultConnectorDeprecated(address connector);
 
     /**
      * @dev Emitted every time a smart vault is paused

--- a/packages/smart-vault/test/SmartVaults.test.ts
+++ b/packages/smart-vault/test/SmartVaults.test.ts
@@ -103,14 +103,14 @@ describe('SmartVault', () => {
         })
 
         it('cannot be paused', async () => {
-          await expect(smartVault.pause()).to.be.revertedWith('SMART_VAULT_ALREADY_PAUSED')
+          await expect(smartVault.pause()).to.be.revertedWith('SmartVaultAlreadyPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.pause()).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.pause()).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -125,7 +125,7 @@ describe('SmartVault', () => {
 
       context('when the smart vault is not paused', () => {
         it('cannot be unpaused', async () => {
-          await expect(smartVault.unpause()).to.be.revertedWith('SMART_VAULT_ALREADY_UNPAUSED')
+          await expect(smartVault.unpause()).to.be.revertedWith('SmartVaultAlreadyUnpaused')
         })
       })
 
@@ -148,7 +148,7 @@ describe('SmartVault', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.unpause()).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.unpause()).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -189,14 +189,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.setPriceOracle(priceOracle.address)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.setPriceOracle(priceOracle.address)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.setPriceOracle(priceOracle.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.setPriceOracle(priceOracle.address)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -265,7 +265,7 @@ describe('SmartVault', () => {
 
         it('reverts', async () => {
           await expect(smartVault.overrideConnectorCheck(connector.address, true)).to.be.revertedWith(
-            'SMART_VAULT_PAUSED'
+            'SmartVaultPaused'
           )
         })
       })
@@ -274,7 +274,7 @@ describe('SmartVault', () => {
     context('when sender is not authorized', () => {
       it('reverts', async () => {
         await expect(smartVault.overrideConnectorCheck(connector.address, true)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -352,7 +352,7 @@ describe('SmartVault', () => {
               it('reverts', async () => {
                 await expect(
                   smartVault.updateBalanceConnector(connector, token.address, amount, add)
-                ).to.be.revertedWith('SMART_VAULT_CONNECTOR_NO_BALANCE')
+                ).to.be.revertedWith('SmartVaultConnectorInsuffBalance')
               })
             })
           })
@@ -363,7 +363,7 @@ describe('SmartVault', () => {
 
           it('reverts', async () => {
             await expect(smartVault.updateBalanceConnector(connector, token, amount, true)).to.be.revertedWith(
-              'SMART_VAULT_CONNECTOR_TOKEN_ZERO'
+              'SmartVaultConnectorInputZero'
             )
           })
         })
@@ -374,7 +374,7 @@ describe('SmartVault', () => {
 
         it('reverts', async () => {
           await expect(smartVault.updateBalanceConnector(connector, ZERO_ADDRESS, amount, true)).to.be.revertedWith(
-            'SMART_VAULT_CONNECTOR_ID_ZERO'
+            'SmartVaultConnectorInputZero'
           )
         })
       })
@@ -383,7 +383,7 @@ describe('SmartVault', () => {
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
         await expect(smartVault.updateBalanceConnector(ZERO_BYTES32, ZERO_ADDRESS, amount, true)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -451,7 +451,7 @@ describe('SmartVault', () => {
 
               it('reverts', async () => {
                 await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
-                  'SMART_VAULT_CON_DEPRECATED'
+                  'SmartVaultInvalidConnector'
                 )
               })
             })
@@ -465,9 +465,7 @@ describe('SmartVault', () => {
             })
 
             it('reverts', async () => {
-              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
-                'SMART_VAULT_CON_NOT_STATELESS'
-              )
+              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SmartVaultInvalidConnector')
             })
           })
         })
@@ -475,9 +473,7 @@ describe('SmartVault', () => {
         context('when the connector is not registered', async () => {
           context('when the connector check is not overridden', async () => {
             it('reverts', async () => {
-              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
-                'SMART_VAULT_CON_NOT_REGISTERED'
-              )
+              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SmartVaultInvalidConnector')
             })
           })
 
@@ -501,14 +497,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -571,14 +567,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.call(target.address, '0x', value)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.call(target.address, '0x', value)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.call(target.address, '0x', value)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.call(target.address, '0x', value)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -650,16 +646,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.collect(token.address, from.address, amount)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.collect(token.address, from.address, amount)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.collect(token.address, from.address, amount)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(smartVault.collect(token.address, from.address, amount)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -793,9 +787,7 @@ describe('SmartVault', () => {
 
         context('when the fee percentage was not set', async () => {
           it('reverts', async () => {
-            await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, amount)).to.be.revertedWith(
-              'FEE_CONTROLLER_SV_NOT_SET'
-            )
+            await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, amount)).to.be.reverted
           })
         })
       })
@@ -808,16 +800,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, 0)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, 0)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, 0)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(smartVault.withdraw(ZERO_ADDRESS, recipient.address, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -859,7 +849,7 @@ describe('SmartVault', () => {
 
         context('when the smart vault does not have enough native tokens', () => {
           it('reverts', async () => {
-            await expect(smartVault.wrap(amount)).to.be.revertedWith('SMART_VAULT_WRAP_NO_BALANCE')
+            await expect(smartVault.wrap(amount)).to.be.revertedWith('SmartVaultInsufficientBalance')
           })
         })
       })
@@ -872,14 +862,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.wrap(amount)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.wrap(amount)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.wrap(amount)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.wrap(amount)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -935,14 +925,14 @@ describe('SmartVault', () => {
         })
 
         it('reverts', async () => {
-          await expect(smartVault.unwrap(amount)).to.be.revertedWith('SMART_VAULT_PAUSED')
+          await expect(smartVault.unwrap(amount)).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(smartVault.unwrap(amount)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(smartVault.unwrap(amount)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/smart-vault/test/SmartVaults.test.ts
+++ b/packages/smart-vault/test/SmartVaults.test.ts
@@ -19,6 +19,8 @@ import { expect } from 'chai'
 import { Contract } from 'ethers'
 import { ethers } from 'hardhat'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('SmartVault', () => {
   let smartVault: Contract
   let authorizer: Contract, registry: Contract, feeController: Contract, wrappedNT: Contract
@@ -103,7 +105,7 @@ describe('SmartVault', () => {
         })
 
         it('cannot be paused', async () => {
-          await expect(smartVault.pause()).to.be.revertedWith('SmartVaultAlreadyPaused')
+          await expect(smartVault.pause()).to.be.revertedWith('SmartVaultPaused')
         })
       })
     })
@@ -352,7 +354,7 @@ describe('SmartVault', () => {
               it('reverts', async () => {
                 await expect(
                   smartVault.updateBalanceConnector(connector, token.address, amount, add)
-                ).to.be.revertedWith('SmartVaultConnectorInsuffBalance')
+                ).to.be.revertedWith('SmartVaultBalanceConnectorInsufficientBalance')
               })
             })
           })
@@ -363,7 +365,7 @@ describe('SmartVault', () => {
 
           it('reverts', async () => {
             await expect(smartVault.updateBalanceConnector(connector, token, amount, true)).to.be.revertedWith(
-              'SmartVaultConnectorTokenZero'
+              'SmartVaultTokenZero'
             )
           })
         })
@@ -374,7 +376,7 @@ describe('SmartVault', () => {
 
         it('reverts', async () => {
           await expect(smartVault.updateBalanceConnector(connector, ZERO_ADDRESS, amount, true)).to.be.revertedWith(
-            'SmartVaultConnectorIdZero'
+            'SmartVaultBalanceConnectorIdZero'
           )
         })
       })
@@ -853,7 +855,7 @@ describe('SmartVault', () => {
 
         context('when the smart vault does not have enough native tokens', () => {
           it('reverts', async () => {
-            await expect(smartVault.wrap(amount)).to.be.revertedWith('SmartVaultInsufficientBalance')
+            await expect(smartVault.wrap(amount)).to.be.revertedWith('SmartVaultInsufficientNativeTokenBalance')
           })
         })
       })

--- a/packages/smart-vault/test/SmartVaults.test.ts
+++ b/packages/smart-vault/test/SmartVaults.test.ts
@@ -125,7 +125,7 @@ describe('SmartVault', () => {
 
       context('when the smart vault is not paused', () => {
         it('cannot be unpaused', async () => {
-          await expect(smartVault.unpause()).to.be.revertedWith('SmartVaultAlreadyUnpaused')
+          await expect(smartVault.unpause()).to.be.revertedWith('SmartVaultUnpaused')
         })
       })
 
@@ -363,7 +363,7 @@ describe('SmartVault', () => {
 
           it('reverts', async () => {
             await expect(smartVault.updateBalanceConnector(connector, token, amount, true)).to.be.revertedWith(
-              'SmartVaultConnectorInputZero'
+              'SmartVaultConnectorTokenZero'
             )
           })
         })
@@ -374,7 +374,7 @@ describe('SmartVault', () => {
 
         it('reverts', async () => {
           await expect(smartVault.updateBalanceConnector(connector, ZERO_ADDRESS, amount, true)).to.be.revertedWith(
-            'SmartVaultConnectorInputZero'
+            'SmartVaultConnectorIdZero'
           )
         })
       })
@@ -451,7 +451,7 @@ describe('SmartVault', () => {
 
               it('reverts', async () => {
                 await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
-                  'SmartVaultInvalidConnector'
+                  'SmartVaultConnectorDeprecated'
                 )
               })
             })
@@ -465,7 +465,9 @@ describe('SmartVault', () => {
             })
 
             it('reverts', async () => {
-              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SmartVaultInvalidConnector')
+              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
+                'SmartVaultConnectorNotStateless'
+              )
             })
           })
         })
@@ -473,7 +475,9 @@ describe('SmartVault', () => {
         context('when the connector is not registered', async () => {
           context('when the connector check is not overridden', async () => {
             it('reverts', async () => {
-              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith('SmartVaultInvalidConnector')
+              await expect(smartVault.execute(connector.address, data)).to.be.revertedWith(
+                'SmartVaultConnectorNotRegistered'
+              )
             })
           })
 

--- a/packages/tasks/contracts/base/BaseTask.sol
+++ b/packages/tasks/contracts/base/BaseTask.sol
@@ -147,7 +147,7 @@ abstract contract BaseTask is IBaseTask, Authorized {
      */
     function _getPrice(address base, address quote) internal view virtual returns (uint256) {
         address priceOracle = ISmartVault(smartVault).priceOracle();
-        if (priceOracle == address(0)) revert TaskPriceOracleNotSet(base, quote);
+        if (priceOracle == address(0)) revert TaskSmartVaultPriceOracleNotSet(base, quote);
         return IPriceOracle(priceOracle).getPrice(_wrappedIfNative(base), _wrappedIfNative(quote));
     }
 

--- a/packages/tasks/contracts/base/BaseTask.sol
+++ b/packages/tasks/contracts/base/BaseTask.sol
@@ -136,7 +136,7 @@ abstract contract BaseTask is IBaseTask, Authorized {
      * @param next Balance connector id of the next task in the workflow
      */
     function _setBalanceConnectors(bytes32 previous, bytes32 next) internal virtual {
-        require(previous != next || previous == bytes32(0), 'TASK_SAME_BALANCE_CONNECTORS');
+        if (previous == next && previous != bytes32(0)) revert TaskSameBalanceConnectors(previous);
         previousBalanceConnectorId = previous;
         nextBalanceConnectorId = next;
         emit BalanceConnectorsSet(previous, next);
@@ -147,7 +147,7 @@ abstract contract BaseTask is IBaseTask, Authorized {
      */
     function _getPrice(address base, address quote) internal view virtual returns (uint256) {
         address priceOracle = ISmartVault(smartVault).priceOracle();
-        require(priceOracle != address(0), 'TASK_PRICE_ORACLE_NOT_SET');
+        if (priceOracle == address(0)) revert TaskPriceOracleNotSet(base, quote);
         return IPriceOracle(priceOracle).getPrice(_wrappedIfNative(base), _wrappedIfNative(quote));
     }
 

--- a/packages/tasks/contracts/base/GasLimitedTask.sol
+++ b/packages/tasks/contracts/base/GasLimitedTask.sol
@@ -118,7 +118,8 @@ abstract contract GasLimitedTask is IGasLimitedTask, Authorized {
     function _beforeGasLimitedTask(address, uint256) internal virtual {
         __initialGas__ = gasleft();
         if (gasPriceLimit > 0 && tx.gasprice > gasPriceLimit) revert TaskGasPriceLimit(tx.gasprice, gasPriceLimit);
-        if (priorityFeeLimit > 0 && tx.gasprice - block.basefee > priorityFeeLimit) revert TaskPriorityFeeLimit(tx.gasprice, block.basefee, priorityFeeLimit);
+        if (priorityFeeLimit > 0 && tx.gasprice - block.basefee > priorityFeeLimit)
+            revert TaskPriorityFeeLimit(tx.gasprice, block.basefee, priorityFeeLimit);
     }
 
     /**
@@ -136,7 +137,8 @@ abstract contract GasLimitedTask is IGasLimitedTask, Authorized {
             if (amount == 0) revert GasLimitedTaskAmountZero();
             uint256 price = _getPrice(ISmartVault(this.smartVault()).wrappedNativeToken(), token);
             uint256 totalCostInToken = totalCost.mulUp(price);
-            if (totalCostInToken.divUp(amount) > txCostLimitPct) revert TaskTxCostLimitPct(totalCostInToken, amount, txCostLimitPct);
+            if (totalCostInToken.divUp(amount) > txCostLimitPct)
+                revert TaskTxCostLimitPct(totalCostInToken, amount, txCostLimitPct);
         }
     }
 

--- a/packages/tasks/contracts/base/GasLimitedTask.sol
+++ b/packages/tasks/contracts/base/GasLimitedTask.sol
@@ -133,8 +133,7 @@ abstract contract GasLimitedTask is IGasLimitedTask, Authorized {
         if (txCostLimit > 0 && totalCost > txCostLimit) revert TaskTxCostLimit(totalCost, txCostLimit);
         delete __initialGas__;
 
-        if (txCostLimitPct > 0) {
-            if (amount == 0) revert GasLimitedTaskAmountZero();
+        if (txCostLimitPct > 0 && amount > 0) {
             uint256 price = _getPrice(ISmartVault(this.smartVault()).wrappedNativeToken(), token);
             uint256 totalCostInToken = totalCost.mulUp(price);
             if (totalCostInToken.divUp(amount) > txCostLimitPct)

--- a/packages/tasks/contracts/base/PausableTask.sol
+++ b/packages/tasks/contracts/base/PausableTask.sol
@@ -46,7 +46,7 @@ abstract contract PausableTask is IPausableTask, Authorized {
      * @dev Pauses a task
      */
     function pause() external override auth {
-        require(!isPaused, 'TASK_ALREADY_PAUSED');
+        if (isPaused) revert TaskAlreadyPaused();
         isPaused = true;
         emit Paused();
     }
@@ -55,7 +55,7 @@ abstract contract PausableTask is IPausableTask, Authorized {
      * @dev Unpauses a task
      */
     function unpause() external override auth {
-        require(isPaused, 'TASK_ALREADY_UNPAUSED');
+        if (!isPaused) revert TaskAlreadyUnpaused();
         isPaused = false;
         emit Unpaused();
     }
@@ -64,7 +64,7 @@ abstract contract PausableTask is IPausableTask, Authorized {
      * @dev Before pausable task hook
      */
     function _beforePausableTask(address, uint256) internal virtual {
-        require(!isPaused, 'TASK_PAUSED');
+        if (isPaused) revert TaskPaused();
     }
 
     /**

--- a/packages/tasks/contracts/base/PausableTask.sol
+++ b/packages/tasks/contracts/base/PausableTask.sol
@@ -46,7 +46,7 @@ abstract contract PausableTask is IPausableTask, Authorized {
      * @dev Pauses a task
      */
     function pause() external override auth {
-        if (isPaused) revert TaskAlreadyPaused();
+        if (isPaused) revert TaskPaused();
         isPaused = true;
         emit Paused();
     }
@@ -55,7 +55,7 @@ abstract contract PausableTask is IPausableTask, Authorized {
      * @dev Unpauses a task
      */
     function unpause() external override auth {
-        if (!isPaused) revert TaskAlreadyUnpaused();
+        if (!isPaused) revert TaskUnpaused();
         isPaused = false;
         emit Unpaused();
     }

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -96,7 +96,7 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
      * @dev Before time locked task hook
      */
     function _beforeTimeLockedTask(address, uint256) internal virtual {
-        if (block.timestamp < timeLockExpiration) revert TaskTimeLockNotExpired(timeLockExpiration);
+        if (block.timestamp < timeLockExpiration) revert TaskTimeLockNotExpired(timeLockExpiration, block.timestamp);
 
         if (timeLockExecutionPeriod > 0) {
             uint256 diff = block.timestamp - timeLockExpiration;

--- a/packages/tasks/contracts/base/TokenIndexedTask.sol
+++ b/packages/tasks/contracts/base/TokenIndexedTask.sol
@@ -81,7 +81,7 @@ abstract contract TokenIndexedTask is ITokenIndexedTask, Authorized {
      * @param added Whether each of the given tokens should be added or removed from the list
      */
     function setTokensAcceptanceList(address[] memory tokens, bool[] memory added) external override auth {
-        require(tokens.length == added.length, 'TASK_ACCEPTANCE_BAD_LENGTH');
+        if (tokens.length != added.length) revert TaskAcceptanceBadLength(tokens.length, added.length);
         for (uint256 i = 0; i < tokens.length; i++) {
             _setTokenAcceptanceList(tokens[i], added[i]);
         }
@@ -93,7 +93,7 @@ abstract contract TokenIndexedTask is ITokenIndexedTask, Authorized {
     function _beforeTokenIndexedTask(address token, uint256) internal virtual {
         bool containsToken = _tokens.contains(token);
         bool isTokenAllowed = tokensAcceptanceType == TokensAcceptanceType.AllowList ? containsToken : !containsToken;
-        require(isTokenAllowed, 'TASK_TOKEN_NOT_ALLOWED');
+        if (!isTokenAllowed) revert TaskTokenNotAllowed(token);
     }
 
     /**
@@ -118,7 +118,7 @@ abstract contract TokenIndexedTask is ITokenIndexedTask, Authorized {
      * @param added Whether the token should be added or removed from the list
      */
     function _setTokenAcceptanceList(address token, bool added) internal {
-        require(token != address(0), 'TASK_ACCEPTANCE_TOKEN_ZERO');
+        if (token == address(0)) revert TaskAcceptanceTokenZero();
         added ? _tokens.add(token) : _tokens.remove(token);
         emit TokensAcceptanceListSet(token, added);
     }

--- a/packages/tasks/contracts/base/TokenIndexedTask.sol
+++ b/packages/tasks/contracts/base/TokenIndexedTask.sol
@@ -81,7 +81,7 @@ abstract contract TokenIndexedTask is ITokenIndexedTask, Authorized {
      * @param added Whether each of the given tokens should be added or removed from the list
      */
     function setTokensAcceptanceList(address[] memory tokens, bool[] memory added) external override auth {
-        if (tokens.length != added.length) revert TaskAcceptanceBadLength(tokens.length, added.length);
+        if (tokens.length != added.length) revert TaskAcceptanceInputLengthMismatch();
         for (uint256 i = 0; i < tokens.length; i++) {
             _setTokenAcceptanceList(tokens[i], added[i]);
         }

--- a/packages/tasks/contracts/base/TokenThresholdTask.sol
+++ b/packages/tasks/contracts/base/TokenThresholdTask.sol
@@ -142,7 +142,7 @@ abstract contract TokenThresholdTask is ITokenThresholdTask, Authorized {
 
         uint256 convertedAmount = threshold.token == token ? amount : amount.mulDown(_getPrice(token, threshold.token));
         bool isValid = convertedAmount >= threshold.min && (threshold.max == 0 || convertedAmount <= threshold.max);
-        require(isValid, 'TASK_TOKEN_THRESHOLD_NOT_MET');
+        if (!isValid) revert TaskTokenThresholdNotMet(threshold.token, convertedAmount, threshold.min, threshold.max);
     }
 
     /**
@@ -173,7 +173,7 @@ abstract contract TokenThresholdTask is ITokenThresholdTask, Authorized {
     function _setCustomTokenThreshold(address token, address thresholdToken, uint256 thresholdMin, uint256 thresholdMax)
         internal
     {
-        require(token != address(0), 'TASK_THRESHOLD_TOKEN_ZERO');
+        if (token == address(0)) revert TaskThresholdTokenZero();
         _setTokenThreshold(_customThresholds[token], thresholdToken, thresholdMin, thresholdMax);
         emit CustomTokenThresholdSet(token, thresholdToken, thresholdMin, thresholdMax);
     }
@@ -189,7 +189,7 @@ abstract contract TokenThresholdTask is ITokenThresholdTask, Authorized {
         // If there is no threshold, all values must be zero
         bool isZeroThreshold = token == address(0) && min == 0 && max == 0;
         bool isNonZeroThreshold = token != address(0) && (max == 0 || max >= min);
-        require(isZeroThreshold || isNonZeroThreshold, 'TASK_INVALID_THRESHOLD_INPUT');
+        if (!isZeroThreshold && !isNonZeroThreshold) revert TaskInvalidThresholdInput(token, min, max);
 
         threshold.token = token;
         threshold.min = min;

--- a/packages/tasks/contracts/bridge/BaseBridgeTask.sol
+++ b/packages/tasks/contracts/bridge/BaseBridgeTask.sol
@@ -187,10 +187,11 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      */
     function _beforeBaseBridgeTask(address token, uint256 amount, uint256 slippage) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
-        require(getDestinationChain(token) != 0, 'TASK_DESTINATION_CHAIN_NOT_SET');
-        require(slippage <= getMaxSlippage(token), 'TASK_SLIPPAGE_TOO_HIGH');
+        if (token == address(0)) revert TaskTokenZero();
+        if (amount == 0) revert TaskAmountZero();
+        if (getDestinationChain(token) == 0) revert TaskDestinationChainNotSet();
+        uint256 maxSlippage = getMaxSlippage(token);
+        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
     }
 
     /**
@@ -206,7 +207,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param next Balance connector id of the next task in the workflow
      */
     function _setBalanceConnectors(bytes32 previous, bytes32 next) internal virtual override {
-        require(next == bytes32(0), 'TASK_NEXT_CONNECTOR_NOT_ZERO');
+        if (next != bytes32(0)) revert TaskNextConnectorNotZero(next);
         super._setBalanceConnectors(previous, next);
     }
 
@@ -215,7 +216,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param newConnector Address of the connector to be set
      */
     function _setConnector(address newConnector) internal {
-        require(newConnector != address(0), 'TASK_CONNECTOR_ZERO');
+        if (newConnector == address(0)) revert TaskConnectorZero();
         connector = newConnector;
         emit ConnectorSet(newConnector);
     }
@@ -225,7 +226,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param newRecipient Address of the new recipient to be set
      */
     function _setRecipient(address newRecipient) internal {
-        require(newRecipient != address(0), 'TASK_RECIPIENT_ZERO');
+        if (newRecipient == address(0)) revert TaskRecipientZero();
         recipient = newRecipient;
         emit RecipientSet(newRecipient);
     }
@@ -235,7 +236,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param destinationChain Default destination chain to be set
      */
     function _setDefaultDestinationChain(uint256 destinationChain) internal {
-        require(destinationChain != block.chainid, 'TASK_BRIDGE_CURRENT_CHAIN_ID');
+        if (destinationChain == block.chainid) revert TaskBridgeCurrentChainId(destinationChain);
         defaultDestinationChain = destinationChain;
         emit DefaultDestinationChainSet(destinationChain);
     }
@@ -245,7 +246,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param maxSlippage Default max slippage to be set
      */
     function _setDefaultMaxSlippage(uint256 maxSlippage) internal {
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         defaultMaxSlippage = maxSlippage;
         emit DefaultMaxSlippageSet(maxSlippage);
     }
@@ -256,8 +257,8 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param destinationChain Destination chain to be set
      */
     function _setCustomDestinationChain(address token, uint256 destinationChain) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(destinationChain != block.chainid, 'TASK_BRIDGE_CURRENT_CHAIN_ID');
+        if (token == address(0)) revert TaskTokenZero();
+        if (destinationChain == block.chainid) revert TaskBridgeCurrentChainId(destinationChain);
         customDestinationChain[token] = destinationChain;
         emit CustomDestinationChainSet(token, destinationChain);
     }
@@ -268,8 +269,8 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
      * @param maxSlippage Max slippage to be set
      */
     function _setCustomMaxSlippage(address token, uint256 maxSlippage) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (token == address(0)) revert TaskTokenZero();
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         customMaxSlippage[token] = maxSlippage;
         emit CustomMaxSlippageSet(token, maxSlippage);
     }

--- a/packages/tasks/contracts/bridge/BaseBridgeTask.sol
+++ b/packages/tasks/contracts/bridge/BaseBridgeTask.sol
@@ -191,7 +191,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
         if (amount == 0) revert TaskAmountZero();
         if (getDestinationChain(token) == 0) revert TaskDestinationChainNotSet();
         uint256 maxSlippage = getMaxSlippage(token);
-        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
+        if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }
 
     /**

--- a/packages/tasks/contracts/bridge/BaseBridgeTask.sol
+++ b/packages/tasks/contracts/bridge/BaseBridgeTask.sol
@@ -190,6 +190,7 @@ abstract contract BaseBridgeTask is IBaseBridgeTask, Task {
         if (token == address(0)) revert TaskTokenZero();
         if (amount == 0) revert TaskAmountZero();
         if (getDestinationChain(token) == 0) revert TaskDestinationChainNotSet();
+
         uint256 maxSlippage = getMaxSlippage(token);
         if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }

--- a/packages/tasks/contracts/bridge/ConnextBridger.sol
+++ b/packages/tasks/contracts/bridge/ConnextBridger.sol
@@ -82,10 +82,10 @@ contract ConnextBridger is IConnextBridger, BaseBridgeTask {
     }
 
     /**
-     * @dev Tells the relayer fee that should be used for a token
+     * @dev Tells the max fee percentage that should be used for a token
      * @param token Address of the token being queried
      */
-    function getRelayerFee(address token) public view virtual override returns (uint256) {
+    function getMaxFeePct(address token) public view virtual override returns (uint256) {
         uint256 relayerFee = customRelayerFee[token];
         return relayerFee == 0 ? defaultRelayerFee : relayerFee;
     }
@@ -140,9 +140,9 @@ contract ConnextBridger is IConnextBridger, BaseBridgeTask {
         virtual
     {
         _beforeBaseBridgeTask(token, amount, slippage);
-        uint256 maxRelayerFee = getRelayerFee(token);
+        uint256 maxFeePct = getMaxFeePct(token);
         uint256 relayerFeePct = relayerFee.divUp(amount);
-        if (relayerFeePct > maxRelayerFee) revert TaskFeeTooHigh(relayerFeePct, maxRelayerFee);
+        if (relayerFeePct > maxFeePct) revert TaskFeeTooHigh(relayerFeePct, maxFeePct);
     }
 
     /**

--- a/packages/tasks/contracts/bridge/ConnextBridger.sol
+++ b/packages/tasks/contracts/bridge/ConnextBridger.sol
@@ -141,8 +141,8 @@ contract ConnextBridger is IConnextBridger, BaseBridgeTask {
     {
         _beforeBaseBridgeTask(token, amount, slippage);
         uint256 maxFeePct = getMaxFeePct(token);
-        uint256 relayerFeePct = relayerFee.divUp(amount);
-        if (relayerFeePct > maxFeePct) revert TaskFeeTooHigh(relayerFeePct, maxFeePct);
+        uint256 feePct = relayerFee.divUp(amount);
+        if (feePct > maxFeePct) revert TaskFeePctAboveMax(feePct, maxFeePct);
     }
 
     /**

--- a/packages/tasks/contracts/bridge/ConnextBridger.sol
+++ b/packages/tasks/contracts/bridge/ConnextBridger.sol
@@ -140,7 +140,9 @@ contract ConnextBridger is IConnextBridger, BaseBridgeTask {
         virtual
     {
         _beforeBaseBridgeTask(token, amount, slippage);
-        require(relayerFee.divUp(amount) <= getRelayerFee(token), 'TASK_FEE_TOO_HIGH');
+        uint256 maxRelayerFee = getRelayerFee(token);
+        uint256 relayerFeePct = relayerFee.divUp(amount);
+        if (relayerFeePct > maxRelayerFee) revert TaskFeeTooHigh(relayerFeePct, maxRelayerFee);
     }
 
     /**
@@ -165,7 +167,7 @@ contract ConnextBridger is IConnextBridger, BaseBridgeTask {
      * @param relayerFee Relayer fee to be set
      */
     function _setCustomRelayerFee(address token, uint256 relayerFee) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
         customRelayerFee[token] = relayerFee;
         emit CustomRelayerFeeSet(token, relayerFee);
     }

--- a/packages/tasks/contracts/bridge/HopBridger.sol
+++ b/packages/tasks/contracts/bridge/HopBridger.sol
@@ -203,7 +203,7 @@ contract HopBridger is IHopBridger, BaseBridgeTask {
         if (tokenHopEntrypoint[token] == address(0)) revert TaskMissingHopEntrypoint();
         uint256 maxFeePct = getMaxFeePct(token);
         uint256 feePct = fee.divUp(amount);
-        if (feePct > maxFeePct) revert TaskFeeTooHigh(feePct, maxFeePct);
+        if (feePct > maxFeePct) revert TaskFeePctAboveMax(feePct, maxFeePct);
     }
 
     /**

--- a/packages/tasks/contracts/bridge/HopBridger.sol
+++ b/packages/tasks/contracts/bridge/HopBridger.sol
@@ -200,8 +200,10 @@ contract HopBridger is IHopBridger, BaseBridgeTask {
      */
     function _beforeHopBridger(address token, uint256 amount, uint256 slippage, uint256 fee) internal virtual {
         _beforeBaseBridgeTask(token, amount, slippage);
-        require(tokenHopEntrypoint[token] != address(0), 'TASK_MISSING_HOP_ENTRYPOINT');
-        require(fee.divUp(amount) <= getMaxFeePct(token), 'TASK_FEE_TOO_HIGH');
+        if (tokenHopEntrypoint[token] == address(0)) revert TaskMissingHopEntrypoint();
+        uint256 maxFeePct = getMaxFeePct(token);
+        uint256 feePct = fee.divUp(amount);
+        if (feePct > maxFeePct) revert TaskFeeTooHigh(feePct, maxFeePct);
     }
 
     /**
@@ -223,7 +225,7 @@ contract HopBridger is IHopBridger, BaseBridgeTask {
      * @dev Sets the max deadline
      */
     function _setMaxDeadline(uint256 _maxDeadline) internal {
-        require(_maxDeadline > 0, 'TASK_MAX_DEADLINE_ZERO');
+        if (_maxDeadline == 0) revert TaskMaxDeadlineZero();
         maxDeadline = _maxDeadline;
         emit MaxDeadlineSet(_maxDeadline);
     }
@@ -243,7 +245,7 @@ contract HopBridger is IHopBridger, BaseBridgeTask {
      * @param entrypoint Hop entrypoint to be set
      */
     function _setTokenHopEntrypoint(address token, address entrypoint) internal {
-        require(token != address(0), 'TASK_HOP_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
         tokenHopEntrypoint[token] = entrypoint;
         emit TokenHopEntrypointSet(token, entrypoint);
     }
@@ -254,7 +256,7 @@ contract HopBridger is IHopBridger, BaseBridgeTask {
      * @param maxFeePct Max fee percentage to be set for the given token
      */
     function _setCustomMaxFeePct(address token, uint256 maxFeePct) internal {
-        require(token != address(0), 'TASK_HOP_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
         customMaxFeePct[token] = maxFeePct;
         emit CustomMaxFeePctSet(token, maxFeePct);
     }

--- a/packages/tasks/contracts/interfaces/ITask.sol
+++ b/packages/tasks/contracts/interfaces/ITask.sol
@@ -43,16 +43,6 @@ interface ITask is
     error TaskTokenZero();
 
     /**
-     * @dev The token out is not set
-     */
-    error TaskTokenOutNotSet();
-
-    /**
-     * @dev The slippage is higher than the maximum slippage
-     */
-    error TaskSlippageTooHigh(uint256 slippage, uint256 maxSlippage);
-
-    /**
      * @dev The connector is zero
      */
     error TaskConnectorZero();
@@ -61,19 +51,4 @@ interface ITask is
      * @dev The recipient is zero
      */
     error TaskRecipientZero();
-
-    /**
-     * @dev The slippage to be set is higher than one
-     */
-    error TaskSlippageAboveOne();
-
-    /**
-     * @dev The next connector is not zero
-     */
-    error TaskNextConnectorNotZero(bytes32 next);
-
-    /**
-     * @dev The previous connector is not zero
-     */
-    error TaskPreviousConnectorNotZero(bytes32 previous);
 }

--- a/packages/tasks/contracts/interfaces/ITask.sol
+++ b/packages/tasks/contracts/interfaces/ITask.sol
@@ -21,8 +21,6 @@ import './base/ITokenIndexedTask.sol';
 import './base/ITokenThresholdTask.sol';
 import './base/IVolumeLimitedTask.sol';
 
-// solhint-disable no-empty-blocks
-
 /**
  * @dev Task interface
  */
@@ -34,5 +32,49 @@ interface ITask is
     ITokenThresholdTask,
     IVolumeLimitedTask
 {
+    /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
+     * @dev The token is zero
+     */
+    error TaskTokenZero();
+
+    /**
+     * @dev The token out is not set
+     */
+    error TaskTokenOutNotSet();
+
+    /**
+     * @dev The slippage is higher than the maximum slippage
+     */
+    error TaskSlippageTooHigh(uint256 slippage, uint256 maxSlippage);
+
+    /**
+     * @dev The connector is zero
+     */
+    error TaskConnectorZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error TaskRecipientZero();
+
+    /**
+     * @dev The slippage to be set is higher than one
+     */
+    error TaskSlippageAboveOne();
+
+    /**
+     * @dev The next connector is not zero
+     */
+    error TaskNextConnectorNotZero(bytes32 next);
+
+    /**
+     * @dev The previous connector is not zero
+     */
+    error TaskPreviousConnectorNotZero(bytes32 previous);
 
 }

--- a/packages/tasks/contracts/interfaces/ITask.sol
+++ b/packages/tasks/contracts/interfaces/ITask.sol
@@ -76,5 +76,4 @@ interface ITask is
      * @dev The previous connector is not zero
      */
     error TaskPreviousConnectorNotZero(bytes32 previous);
-
 }

--- a/packages/tasks/contracts/interfaces/ITask.sol
+++ b/packages/tasks/contracts/interfaces/ITask.sol
@@ -21,6 +21,8 @@ import './base/ITokenIndexedTask.sol';
 import './base/ITokenThresholdTask.sol';
 import './base/IVolumeLimitedTask.sol';
 
+// solhint-disable no-empty-blocks
+
 /**
  * @dev Task interface
  */
@@ -32,23 +34,5 @@ interface ITask is
     ITokenThresholdTask,
     IVolumeLimitedTask
 {
-    /**
-     * @dev The amount is zero
-     */
-    error TaskAmountZero();
 
-    /**
-     * @dev The token is zero
-     */
-    error TaskTokenZero();
-
-    /**
-     * @dev The connector is zero
-     */
-    error TaskConnectorZero();
-
-    /**
-     * @dev The recipient is zero
-     */
-    error TaskRecipientZero();
 }

--- a/packages/tasks/contracts/interfaces/base/IBaseTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IBaseTask.sol
@@ -25,6 +25,16 @@ interface IBaseTask is IAuthorized {
     function EXECUTION_TYPE() external view returns (bytes32);
 
     /**
+     * @dev The balance connectors are the same
+     */
+    error TaskSameBalanceConnectors(bytes32 connectorId);
+
+    /**
+     * @dev The price oracle is not set
+     */
+    error TaskPriceOracleNotSet(address base, address quote);
+
+    /**
      * @dev Emitted every time a task is executed
      */
     event Executed();

--- a/packages/tasks/contracts/interfaces/base/IBaseTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IBaseTask.sol
@@ -30,9 +30,9 @@ interface IBaseTask is IAuthorized {
     error TaskSameBalanceConnectors(bytes32 connectorId);
 
     /**
-     * @dev The price oracle is not set
+     * @dev The smart vault's price oracle is not set
      */
-    error TaskPriceOracleNotSet(address base, address quote);
+    error TaskSmartVaultPriceOracleNotSet(address base, address quote);
 
     /**
      * @dev Emitted every time a task is executed

--- a/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
@@ -21,6 +21,41 @@ import './IBaseTask.sol';
  */
 interface IGasLimitedTask is IBaseTask {
     /**
+     * @dev The gas price is higher than the limit
+     */
+    error TaskGasPriceLimit(uint256 gasPrice, uint256 gasPriceLimit);
+
+    /**
+     * @dev The gas price minus the base fee is higher than the priority fee limit
+     */
+    error TaskPriorityFeeLimit(uint256 gasPrice, uint256 baseFee, uint256 priorityFeeLimit);
+
+    /**
+     * @dev The initial gas is zero
+     */
+    error TaskGasNotInitialized();
+
+    /**
+     * @dev The transaction cost is higher than the limit
+     */
+    error TaskTxCostLimit(uint256 totalCost, uint256 txCostLimit);
+
+    /**
+     * @dev The transaction cost divided by the amount is higher than the limit percentage
+     */
+    error TaskTxCostLimitPct(uint256 totalCost, uint256 amount, uint256 txCostLimitPct);
+
+    /**
+     * @dev The new transaction cost limit percentage is higher than one
+     */
+    error TaskTxCostLimitPctAboveOne();
+
+    /**
+     * @dev The amount is zero
+     */
+    error GasLimitedTaskAmountZero();
+
+    /**
      * @dev Emitted every time the gas price limit is set
      */
     event GasPriceLimitSet(uint256 gasPriceLimit);

--- a/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
@@ -21,32 +21,32 @@ import './IBaseTask.sol';
  */
 interface IGasLimitedTask is IBaseTask {
     /**
-     * @dev The gas price is higher than the limit
-     */
-    error TaskGasPriceLimit(uint256 gasPrice, uint256 gasPriceLimit);
-
-    /**
-     * @dev The gas price minus the base fee is higher than the priority fee limit
-     */
-    error TaskPriorityFeeLimit(uint256 gasPrice, uint256 baseFee, uint256 priorityFeeLimit);
-
-    /**
-     * @dev The initial gas is zero
+     * @dev The tx initial gas cache has not been initialized
      */
     error TaskGasNotInitialized();
 
     /**
-     * @dev The transaction cost is higher than the limit
+     * @dev The gas price used is greater than the limit
      */
-    error TaskTxCostLimit(uint256 totalCost, uint256 txCostLimit);
+    error TaskGasPriceLimitExceeded(uint256 gasPrice, uint256 gasPriceLimit);
 
     /**
-     * @dev The transaction cost divided by the amount is higher than the limit percentage
+     * @dev The priority fee used is greater than the priority fee limit
      */
-    error TaskTxCostLimitPct(uint256 totalCost, uint256 amount, uint256 txCostLimitPct);
+    error TaskPriorityFeeLimitExceeded(uint256 priorityFee, uint256 priorityFeeLimit);
 
     /**
-     * @dev The new transaction cost limit percentage is higher than one
+     * @dev The transaction cost is greater than the transaction cost limit
+     */
+    error TaskTxCostLimitExceeded(uint256 txCost, uint256 txCostLimit);
+
+    /**
+     * @dev The transaction cost percentage is greater than the transaction cost limit percentage
+     */
+    error TaskTxCostLimitPctExceeded(uint256 txCostPct, uint256 txCostLimitPct);
+
+    /**
+     * @dev The new transaction cost limit percentage is greater than one
      */
     error TaskTxCostLimitPctAboveOne();
 

--- a/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IGasLimitedTask.sol
@@ -51,11 +51,6 @@ interface IGasLimitedTask is IBaseTask {
     error TaskTxCostLimitPctAboveOne();
 
     /**
-     * @dev The amount is zero
-     */
-    error GasLimitedTaskAmountZero();
-
-    /**
      * @dev Emitted every time the gas price limit is set
      */
     event GasPriceLimitSet(uint256 gasPriceLimit);

--- a/packages/tasks/contracts/interfaces/base/IPausableTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IPausableTask.sol
@@ -26,14 +26,9 @@ interface IPausableTask is IBaseTask {
     error TaskPaused();
 
     /**
-     * @dev The task is already paused
+     * @dev The task is unpaused
      */
-    error TaskAlreadyPaused();
-
-    /**
-     * @dev The task is already unpaused
-     */
-    error TaskAlreadyUnpaused();
+    error TaskUnpaused();
 
     /**
      * @dev Emitted every time a task is paused

--- a/packages/tasks/contracts/interfaces/base/IPausableTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IPausableTask.sol
@@ -21,6 +21,21 @@ import './IBaseTask.sol';
  */
 interface IPausableTask is IBaseTask {
     /**
+     * @dev The task is paused
+     */
+    error TaskPaused();
+
+    /**
+     * @dev The task is already paused
+     */
+    error TaskAlreadyPaused();
+
+    /**
+     * @dev The task is already unpaused
+     */
+    error TaskAlreadyUnpaused();
+
+    /**
      * @dev Emitted every time a task is paused
      */
     event Paused();

--- a/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
@@ -23,12 +23,12 @@ interface ITimeLockedTask is IBaseTask {
     /**
      * @dev The time-lock has not expired
      */
-    error TaskTimeLockNotExpired(uint256 timeLockExpiration);
+    error TaskTimeLockNotExpired(uint256 expiration, uint256 currentTimestamp);
 
     /**
      * @dev The execution period has expired
      */
-    error TaskTimeLockWaitNextPeriod(uint256 offset, uint256 timeLockExecutionPeriod);
+    error TaskTimeLockWaitNextPeriod(uint256 offset, uint256 executionPeriod);
 
     /**
      * @dev The execution period is greater than the time-lock delay

--- a/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
@@ -21,6 +21,21 @@ import './IBaseTask.sol';
  */
 interface ITimeLockedTask is IBaseTask {
     /**
+     * @dev The time-lock has not expired
+     */
+    error TaskTimeLockNotExpired(uint256 timeLockExpiration);
+
+    /**
+     * @dev The execution period has expired
+     */
+    error TaskTimeLockWaitNextPeriod(uint256 offset, uint256 timeLockExecutionPeriod);
+
+    /**
+     * @dev The execution period is greater than the time-lock delay
+     */
+    error TaskExecutionPeriodGtDelay(uint256 executionPeriod, uint256 delay);
+
+    /**
      * @dev Emitted every time a new time-lock delay is set
      */
     event TimeLockDelaySet(uint256 delay);

--- a/packages/tasks/contracts/interfaces/base/ITokenIndexedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITokenIndexedTask.sol
@@ -29,6 +29,21 @@ interface ITokenIndexedTask is IBaseTask {
     }
 
     /**
+     * @dev The tokens list length is not the same as the added list length
+     */
+    error TaskAcceptanceBadLength(uint256 tokensLength, uint256 addedLength);
+
+    /**
+     * @dev The token is not allowed
+     */
+    error TaskTokenNotAllowed(address token);
+
+    /**
+     * @dev The acceptance token is zero
+     */
+    error TaskAcceptanceTokenZero();
+
+    /**
      * @dev Emitted every time a tokens acceptance type is set
      */
     event TokensAcceptanceTypeSet(TokensAcceptanceType acceptanceType);

--- a/packages/tasks/contracts/interfaces/base/ITokenIndexedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITokenIndexedTask.sol
@@ -29,19 +29,19 @@ interface ITokenIndexedTask is IBaseTask {
     }
 
     /**
-     * @dev The tokens list length is not the same as the added list length
+     * @dev The acceptance token is zero
      */
-    error TaskAcceptanceBadLength(uint256 tokensLength, uint256 addedLength);
+    error TaskAcceptanceTokenZero();
+
+    /**
+     * @dev The tokens acceptance input length mismatch
+     */
+    error TaskAcceptanceInputLengthMismatch();
 
     /**
      * @dev The token is not allowed
      */
     error TaskTokenNotAllowed(address token);
-
-    /**
-     * @dev The acceptance token is zero
-     */
-    error TaskAcceptanceTokenZero();
 
     /**
      * @dev Emitted every time a tokens acceptance type is set

--- a/packages/tasks/contracts/interfaces/base/ITokenThresholdTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITokenThresholdTask.sol
@@ -30,11 +30,6 @@ interface ITokenThresholdTask is IBaseTask {
     }
 
     /**
-     * @dev The token threshold has not been met
-     */
-    error TaskTokenThresholdNotMet(address thresholdToken, uint256 convertedAmount, uint256 min, uint256 max);
-
-    /**
      * @dev The token threshold token is zero
      */
     error TaskThresholdTokenZero();
@@ -43,6 +38,11 @@ interface ITokenThresholdTask is IBaseTask {
      * @dev The token threshold to be set is invalid
      */
     error TaskInvalidThresholdInput(address token, uint256 min, uint256 max);
+
+    /**
+     * @dev The token threshold has not been met
+     */
+    error TaskTokenThresholdNotMet(address token, uint256 amount, uint256 min, uint256 max);
 
     /**
      * @dev Emitted every time a default threshold is set

--- a/packages/tasks/contracts/interfaces/base/ITokenThresholdTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITokenThresholdTask.sol
@@ -30,6 +30,21 @@ interface ITokenThresholdTask is IBaseTask {
     }
 
     /**
+     * @dev The token threshold has not been met
+     */
+    error TaskTokenThresholdNotMet(address thresholdToken, uint256 convertedAmount, uint256 min, uint256 max);
+
+    /**
+     * @dev The token threshold token is zero
+     */
+    error TaskThresholdTokenZero();
+
+    /**
+     * @dev The token threshold to be set is invalid
+     */
+    error TaskInvalidThresholdInput(address token, uint256 min, uint256 max);
+
+    /**
      * @dev Emitted every time a default threshold is set
      */
     event DefaultTokenThresholdSet(address token, uint256 min, uint256 max);

--- a/packages/tasks/contracts/interfaces/base/IVolumeLimitedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IVolumeLimitedTask.sol
@@ -33,6 +33,21 @@ interface IVolumeLimitedTask is IBaseTask {
     }
 
     /**
+     * @dev The volume limit has been exceeded
+     */
+    error TaskVolumeLimitExceeded(address limitToken, uint256 limitAmount, uint256 processedVolume);
+
+    /**
+     * @dev The volume limit token is zero
+     */
+    error TaskVolumeLimitTokenZero();
+
+    /**
+     * @dev The volume limit to be set is invalid
+     */
+    error TaskInvalidVolumeLimitInput(address token, uint256 amount, uint256 period);
+
+    /**
      * @dev Emitted every time a default volume limit is set
      */
     event DefaultVolumeLimitSet(address indexed token, uint256 amount, uint256 period);

--- a/packages/tasks/contracts/interfaces/base/IVolumeLimitedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/IVolumeLimitedTask.sol
@@ -33,11 +33,6 @@ interface IVolumeLimitedTask is IBaseTask {
     }
 
     /**
-     * @dev The volume limit has been exceeded
-     */
-    error TaskVolumeLimitExceeded(address limitToken, uint256 limitAmount, uint256 processedVolume);
-
-    /**
      * @dev The volume limit token is zero
      */
     error TaskVolumeLimitTokenZero();
@@ -46,6 +41,11 @@ interface IVolumeLimitedTask is IBaseTask {
      * @dev The volume limit to be set is invalid
      */
     error TaskInvalidVolumeLimitInput(address token, uint256 amount, uint256 period);
+
+    /**
+     * @dev The volume limit has been exceeded
+     */
+    error TaskVolumeLimitExceeded(address token, uint256 limit, uint256 volume);
 
     /**
      * @dev Emitted every time a default volume limit is set

--- a/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
@@ -21,14 +21,29 @@ import '../ITask.sol';
  */
 interface IBaseBridgeTask is ITask {
     /**
-     * @dev The fee is higher than the maximum fee
+     * @dev The token is zero
      */
-    error TaskFeeTooHigh(uint256 feePct, uint256 maxFeePct);
+    error TaskTokenZero();
 
     /**
-     * @dev The destination chain id is the same as the current chain id
+     * @dev The amount is zero
      */
-    error TaskBridgeCurrentChainId(uint256 destinationChain);
+    error TaskAmountZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error TaskRecipientZero();
+
+    /**
+     * @dev The connector is zero
+     */
+    error TaskConnectorZero();
+
+    /**
+     * @dev The next balance connector is not zero
+     */
+    error TaskNextConnectorNotZero(bytes32 id);
 
     /**
      * @dev The destination chain is not set
@@ -36,19 +51,24 @@ interface IBaseBridgeTask is ITask {
     error TaskDestinationChainNotSet();
 
     /**
-     * @dev The slippage is higher than the maximum slippage
+     * @dev The destination chain id is the same as the current chain id
      */
-    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
+    error TaskBridgeCurrentChainId(uint256 destinationChain);
 
     /**
-     * @dev The slippage to be set is higher than one
+     * @dev The slippage to be set is greater than one
      */
     error TaskSlippageAboveOne();
 
     /**
-     * @dev The next connector is not zero
+     * @dev The requested slippage is greater than the maximum slippage
      */
-    error TaskNextConnectorNotZero(bytes32 next);
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
+
+    /**
+     * @dev The requested fee percentage is greater than the maximum fee percentage
+     */
+    error TaskFeePctAboveMax(uint256 feePct, uint256 maxFeePct);
 
     /**
      * @dev Emitted every time the connector is set

--- a/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
@@ -36,6 +36,21 @@ interface IBaseBridgeTask is ITask {
     error TaskDestinationChainNotSet();
 
     /**
+     * @dev The slippage is higher than the maximum slippage
+     */
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
+
+    /**
+     * @dev The slippage to be set is higher than one
+     */
+    error TaskSlippageAboveOne();
+
+    /**
+     * @dev The next connector is not zero
+     */
+    error TaskNextConnectorNotZero(bytes32 next);
+
+    /**
      * @dev Emitted every time the connector is set
      */
     event ConnectorSet(address indexed connector);

--- a/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IBaseBridgeTask.sol
@@ -21,6 +21,21 @@ import '../ITask.sol';
  */
 interface IBaseBridgeTask is ITask {
     /**
+     * @dev The fee is higher than the maximum fee
+     */
+    error TaskFeeTooHigh(uint256 feePct, uint256 maxFeePct);
+
+    /**
+     * @dev The destination chain id is the same as the current chain id
+     */
+    error TaskBridgeCurrentChainId(uint256 destinationChain);
+
+    /**
+     * @dev The destination chain is not set
+     */
+    error TaskDestinationChainNotSet();
+
+    /**
      * @dev Emitted every time the connector is set
      */
     event ConnectorSet(address indexed connector);

--- a/packages/tasks/contracts/interfaces/bridge/IConnextBridger.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IConnextBridger.sol
@@ -41,10 +41,10 @@ interface IConnextBridger is IBaseBridgeTask {
     function customRelayerFee(address token) external view returns (uint256);
 
     /**
-     * @dev Tells the relayer fee that should be used for a token
+     * @dev Tells the max fee percentage that should be used for a token
      * @param token Address of the token being queried
      */
-    function getRelayerFee(address token) external view returns (uint256);
+    function getMaxFeePct(address token) external view returns (uint256);
 
     /**
      * @dev Sets the default relayer fee

--- a/packages/tasks/contracts/interfaces/bridge/IHopBridger.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IHopBridger.sol
@@ -21,6 +21,16 @@ import './IBaseBridgeTask.sol';
  */
 interface IHopBridger is IBaseBridgeTask {
     /**
+     * @dev The entrypoint is zero
+     */
+    error TaskMissingHopEntrypoint();
+
+    /**
+     * @dev The max deadline is zero
+     */
+    error TaskMaxDeadlineZero();
+
+    /**
      * @dev Emitted every time the relayer is set
      */
     event RelayerSet(address indexed relayer);

--- a/packages/tasks/contracts/interfaces/bridge/IHopBridger.sol
+++ b/packages/tasks/contracts/interfaces/bridge/IHopBridger.sol
@@ -21,14 +21,14 @@ import './IBaseBridgeTask.sol';
  */
 interface IHopBridger is IBaseBridgeTask {
     /**
-     * @dev The entrypoint is zero
-     */
-    error TaskMissingHopEntrypoint();
-
-    /**
      * @dev The max deadline is zero
      */
     error TaskMaxDeadlineZero();
+
+    /**
+     * @dev The Hop entrypoint is zero
+     */
+    error TaskMissingHopEntrypoint();
 
     /**
      * @dev Emitted every time the relayer is set

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IBaseConvexTask.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IBaseConvexTask.sol
@@ -21,6 +21,16 @@ import '../../ITask.sol';
  */
 interface IBaseConvexTask is ITask {
     /**
+     * @dev The token is zero
+     */
+    error TaskTokenZero();
+
+    /**
+     * @dev The connector is zero
+     */
+    error TaskConnectorZero();
+
+    /**
      * @dev Emitted every time the connector is set
      */
     event ConnectorSet(address indexed connector);

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
@@ -21,6 +21,16 @@ import './IBaseConvexTask.sol';
  */
 interface IConvexClaimer is IBaseConvexTask {
     /**
+     * @dev The amount is not zero
+     */
+    error TaskAmountNotZero();
+
+    /**
+     * @dev The length of the tokens out is not the same as the length of the amounts out
+     */
+    error ClaimerInvalidResultLength(uint256 tokensOutLength, uint256 amountsOutLength);
+
+    /**
      * @dev Executes the Convex claimer task
      */
     function call(address token, uint256 amount) external;

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
@@ -21,19 +21,19 @@ import './IBaseConvexTask.sol';
  */
 interface IConvexClaimer is IBaseConvexTask {
     /**
-     * @dev The previous connector is not zero
-     */
-    error TaskPreviousConnectorNotZero(bytes32 previous);
-
-    /**
      * @dev The amount is not zero
      */
     error TaskAmountNotZero();
 
     /**
-     * @dev The length of the tokens out is not the same as the length of the amounts out
+     * @dev The previous balance connector is not zero
      */
-    error ClaimerInvalidResultLength(uint256 tokensOutLength, uint256 amountsOutLength);
+    error TaskPreviousConnectorNotZero(bytes32 id);
+
+    /**
+     * @dev The length of the claim result mismatch
+     */
+    error TaskClaimResultLengthMismatch();
 
     /**
      * @dev Executes the Convex claimer task

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IConvexClaimer.sol
@@ -21,6 +21,11 @@ import './IBaseConvexTask.sol';
  */
 interface IConvexClaimer is IBaseConvexTask {
     /**
+     * @dev The previous connector is not zero
+     */
+    error TaskPreviousConnectorNotZero(bytes32 previous);
+
+    /**
      * @dev The amount is not zero
      */
     error TaskAmountNotZero();

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IConvexExiter.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IConvexExiter.sol
@@ -21,6 +21,11 @@ import './IBaseConvexTask.sol';
  */
 interface IConvexExiter is IBaseConvexTask {
     /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev Executes the Convex exiter task
      */
     function call(address token, uint256 amount) external;

--- a/packages/tasks/contracts/interfaces/liquidity/convex/IConvexJoiner.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/convex/IConvexJoiner.sol
@@ -21,6 +21,11 @@ import './IBaseConvexTask.sol';
  */
 interface IConvexJoiner is IBaseConvexTask {
     /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev Executes the Convex joiner task
      */
     function call(address token, uint256 amount) external;

--- a/packages/tasks/contracts/interfaces/liquidity/curve/IBaseCurveTask.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/curve/IBaseCurveTask.sol
@@ -21,19 +21,34 @@ import '../../ITask.sol';
  */
 interface IBaseCurveTask is ITask {
     /**
+     * @dev The token is zero
+     */
+    error TaskTokenZero();
+
+    /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
+     * @dev The connector is zero
+     */
+    error TaskConnectorZero();
+
+    /**
      * @dev The token out is not set
      */
     error TaskTokenOutNotSet();
 
     /**
-     * @dev The slippage is higher than the maximum slippage
-     */
-    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
-
-    /**
-     * @dev The slippage to be set is higher than one
+     * @dev The slippage to be set is greater than one
      */
     error TaskSlippageAboveOne();
+
+    /**
+     * @dev The requested slippage is greater than the maximum slippage
+     */
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
 
     /**
      * @dev Emitted every time the connector is set

--- a/packages/tasks/contracts/interfaces/liquidity/curve/IBaseCurveTask.sol
+++ b/packages/tasks/contracts/interfaces/liquidity/curve/IBaseCurveTask.sol
@@ -21,6 +21,21 @@ import '../../ITask.sol';
  */
 interface IBaseCurveTask is ITask {
     /**
+     * @dev The token out is not set
+     */
+    error TaskTokenOutNotSet();
+
+    /**
+     * @dev The slippage is higher than the maximum slippage
+     */
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
+
+    /**
+     * @dev The slippage to be set is higher than one
+     */
+    error TaskSlippageAboveOne();
+
+    /**
      * @dev Emitted every time the connector is set
      */
     event ConnectorSet(address indexed connector);

--- a/packages/tasks/contracts/interfaces/primitives/ICollector.sol
+++ b/packages/tasks/contracts/interfaces/primitives/ICollector.sol
@@ -31,6 +31,11 @@ interface ICollector is ITask {
     event TokensSourceSet(address indexed tokensSource);
 
     /**
+     * @dev The previous connector is not zero
+     */
+    error TaskPreviousConnectorNotZero(bytes32 previous);
+
+    /**
      * @dev Sets the tokens source address
      * @param tokensSource Address of the tokens source to be set
      */

--- a/packages/tasks/contracts/interfaces/primitives/ICollector.sol
+++ b/packages/tasks/contracts/interfaces/primitives/ICollector.sol
@@ -21,19 +21,29 @@ import '../ITask.sol';
  */
 interface ICollector is ITask {
     /**
+     * @dev The token is zero
+     */
+    error TaskTokenZero();
+
+    /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev The tokens source is zero
      */
     error TaskTokensSourceZero();
 
     /**
+     * @dev The previous balance connector is not zero
+     */
+    error TaskPreviousConnectorNotZero(bytes32 id);
+
+    /**
      * @dev Emitted every time the tokens source is set
      */
     event TokensSourceSet(address indexed tokensSource);
-
-    /**
-     * @dev The previous connector is not zero
-     */
-    error TaskPreviousConnectorNotZero(bytes32 previous);
 
     /**
      * @dev Sets the tokens source address

--- a/packages/tasks/contracts/interfaces/primitives/ICollector.sol
+++ b/packages/tasks/contracts/interfaces/primitives/ICollector.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface ICollector is ITask {
     /**
+     * @dev The tokens source is zero
+     */
+    error TaskTokensSourceZero();
+
+    /**
      * @dev Emitted every time the tokens source is set
      */
     event TokensSourceSet(address indexed tokensSource);

--- a/packages/tasks/contracts/interfaces/primitives/IUnwrapper.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IUnwrapper.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IUnwrapper is ITask {
     /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev The token is not the wrapped native token
      */
     error TaskTokenNotWrapped();

--- a/packages/tasks/contracts/interfaces/primitives/IUnwrapper.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IUnwrapper.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IUnwrapper is ITask {
     /**
+     * @dev The token is not the wrapped native token
+     */
+    error TaskTokenNotWrapped();
+
+    /**
      * @dev Executes the unwrapper task
      */
     function call(address token, uint256 amount) external;

--- a/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
@@ -21,14 +21,29 @@ import '../ITask.sol';
  */
 interface IWithdrawer is ITask {
     /**
-     * @dev The recipient to be set is the smart vault
+     * @dev The token is zero
      */
-    error TaskRecipientSmartVault(address recipient);
+    error TaskTokenZero();
 
     /**
-     * @dev The next connector is not zero
+     * @dev The amount is zero
      */
-    error TaskNextConnectorNotZero(bytes32 next);
+    error TaskAmountZero();
+
+    /**
+     * @dev The recipient is zero
+     */
+    error TaskRecipientZero();
+
+    /**
+     * @dev The recipient to be set is the smart vault
+     */
+    error TaskRecipientEqualsSmartVault(address recipient);
+
+    /**
+     * @dev The next balance connector is not zero
+     */
+    error TaskNextConnectorNotZero(bytes32 id);
 
     /**
      * @dev Emitted every time the recipient is set

--- a/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IWithdrawer is ITask {
     /**
+     * @dev The recipient to be set is the smart vault
+     */
+    error TaskRecipientSmartVault(address recipient);
+
+    /**
      * @dev Emitted every time the recipient is set
      */
     event RecipientSet(address indexed recipient);

--- a/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IWithdrawer.sol
@@ -26,6 +26,11 @@ interface IWithdrawer is ITask {
     error TaskRecipientSmartVault(address recipient);
 
     /**
+     * @dev The next connector is not zero
+     */
+    error TaskNextConnectorNotZero(bytes32 next);
+
+    /**
      * @dev Emitted every time the recipient is set
      */
     event RecipientSet(address indexed recipient);

--- a/packages/tasks/contracts/interfaces/primitives/IWrapper.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IWrapper.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IWrapper is ITask {
     /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev The token is not the native token
      */
     error TaskTokenNotNative();

--- a/packages/tasks/contracts/interfaces/primitives/IWrapper.sol
+++ b/packages/tasks/contracts/interfaces/primitives/IWrapper.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IWrapper is ITask {
     /**
+     * @dev The token is not the native token
+     */
+    error TaskTokenNotNative();
+
+    /**
      * @dev Executes the wrapper task
      */
     function call(address token, uint256 amount) external;

--- a/packages/tasks/contracts/interfaces/relayer/IBaseRelayerFundTask.sol
+++ b/packages/tasks/contracts/interfaces/relayer/IBaseRelayerFundTask.sol
@@ -21,6 +21,26 @@ import '../ITask.sol';
  */
 interface IBaseRelayerFundTask is ITask {
     /**
+     * @dev The deposited amount is above the minimum threshold plus the used quota
+     */
+    error TaskDepositedAboveMinThreshold(uint256 deposited, uint256 min, uint256 usedQuota);
+
+    /**
+     * @dev The amount plus the deposited is above the maximum threshold plus the used quota
+     */
+    error TaskAmountAboveMaxThreshold(uint256 amount, uint256 deposited, uint256 max, uint256 usedQuota);
+
+    /**
+     * @dev The relayer is zero
+     */
+    error TaskRelayerZero();
+
+    /**
+     * @dev The task initializer is disabled
+     */
+    error TaskInitializerDisabled();
+
+    /**
      * @dev Emitted every time the relayer is set
      */
     event RelayerSet(address indexed relayer);

--- a/packages/tasks/contracts/interfaces/relayer/IBaseRelayerFundTask.sol
+++ b/packages/tasks/contracts/interfaces/relayer/IBaseRelayerFundTask.sol
@@ -21,16 +21,6 @@ import '../ITask.sol';
  */
 interface IBaseRelayerFundTask is ITask {
     /**
-     * @dev The deposited amount is above the minimum threshold plus the used quota
-     */
-    error TaskDepositedAboveMinThreshold(uint256 deposited, uint256 min, uint256 usedQuota);
-
-    /**
-     * @dev The amount plus the deposited is above the maximum threshold plus the used quota
-     */
-    error TaskAmountAboveMaxThreshold(uint256 amount, uint256 deposited, uint256 max, uint256 usedQuota);
-
-    /**
      * @dev The relayer is zero
      */
     error TaskRelayerZero();
@@ -39,6 +29,16 @@ interface IBaseRelayerFundTask is ITask {
      * @dev The task initializer is disabled
      */
     error TaskInitializerDisabled();
+
+    /**
+     * @dev The deposited amount is above the minimum threshold
+     */
+    error TaskDepositAboveMinThreshold(uint256 deposited, uint256 min);
+
+    /**
+     * @dev The requested amount would result in a new balance above the maximum threshold plus the used quota
+     */
+    error TaskDepositAboveMaxThreshold(uint256 newBalance, uint256 max, uint256 usedQuota);
 
     /**
      * @dev Emitted every time the relayer is set

--- a/packages/tasks/contracts/interfaces/relayer/IRelayerDepositor.sol
+++ b/packages/tasks/contracts/interfaces/relayer/IRelayerDepositor.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IRelayerDepositor is ITask {
     /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
      * @dev The relayer is zero
      */
     error TaskRelayerZero();

--- a/packages/tasks/contracts/interfaces/relayer/IRelayerDepositor.sol
+++ b/packages/tasks/contracts/interfaces/relayer/IRelayerDepositor.sol
@@ -21,6 +21,11 @@ import '../ITask.sol';
  */
 interface IRelayerDepositor is ITask {
     /**
+     * @dev The relayer is zero
+     */
+    error TaskRelayerZero();
+
+    /**
      * @dev Emitted every time the relayer is set
      */
     event RelayerSet(address indexed relayer);

--- a/packages/tasks/contracts/interfaces/swap/IBaseSwapTask.sol
+++ b/packages/tasks/contracts/interfaces/swap/IBaseSwapTask.sol
@@ -21,6 +21,21 @@ import '../ITask.sol';
  */
 interface IBaseSwapTask is ITask {
     /**
+     * @dev The token out is not set
+     */
+    error TaskTokenOutNotSet();
+
+    /**
+     * @dev The slippage is higher than the maximum slippage
+     */
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
+
+    /**
+     * @dev The slippage to be set is higher than one
+     */
+    error TaskSlippageAboveOne();
+
+    /**
      * @dev Emitted every time the connector is set
      */
     event ConnectorSet(address indexed connector);

--- a/packages/tasks/contracts/interfaces/swap/IBaseSwapTask.sol
+++ b/packages/tasks/contracts/interfaces/swap/IBaseSwapTask.sol
@@ -21,19 +21,34 @@ import '../ITask.sol';
  */
 interface IBaseSwapTask is ITask {
     /**
+     * @dev The token is zero
+     */
+    error TaskTokenZero();
+
+    /**
+     * @dev The amount is zero
+     */
+    error TaskAmountZero();
+
+    /**
+     * @dev The connector is zero
+     */
+    error TaskConnectorZero();
+
+    /**
      * @dev The token out is not set
      */
     error TaskTokenOutNotSet();
 
     /**
-     * @dev The slippage is higher than the maximum slippage
-     */
-    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
-
-    /**
-     * @dev The slippage to be set is higher than one
+     * @dev The slippage to be set is greater than one
      */
     error TaskSlippageAboveOne();
+
+    /**
+     * @dev The slippage is greater than the maximum slippage
+     */
+    error TaskSlippageAboveMax(uint256 slippage, uint256 maxSlippage);
 
     /**
      * @dev Emitted every time the connector is set

--- a/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
@@ -21,12 +21,12 @@ import './IBaseSwapTask.sol';
  */
 interface IHopL2Swapper is IBaseSwapTask {
     /**
-     * @dev The amm for the token is zero
+     * @dev The amm for the token is not set
      */
     error TaskMissingHopTokenAmm();
 
     /**
-     * @dev The hToken to be set is not the Hop L2 amm hToken
+     * @dev The hToken to be set is not the hToken of the Hop L2 amm to be used
      */
     error TaskHopTokenAmmMismatch(address hToken, address amm);
 

--- a/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
@@ -21,6 +21,16 @@ import './IBaseSwapTask.sol';
  */
 interface IHopL2Swapper is IBaseSwapTask {
     /**
+     * @dev The amm for the token is zero
+     */
+    error TaskMissingHopTokenAmm();
+
+    /**
+     * @dev The hToken to be set is not the Hop L2 amm hToken
+     */
+    error TaskHopTokenAmmMismatch(address hToken, address amm, address hopL2AmmHToken);    
+
+    /**
      * @dev Emitted every time an AMM is set for a token
      */
     event TokenAmmSet(address indexed token, address amm);

--- a/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
@@ -28,7 +28,7 @@ interface IHopL2Swapper is IBaseSwapTask {
     /**
      * @dev The hToken to be set is not the Hop L2 amm hToken
      */
-    error TaskHopTokenAmmMismatch(address hToken, address amm, address hopL2AmmHToken);
+    error TaskHopTokenAmmMismatch(address hToken, address amm);
 
     /**
      * @dev Emitted every time an AMM is set for a token

--- a/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IHopL2Swapper.sol
@@ -28,7 +28,7 @@ interface IHopL2Swapper is IBaseSwapTask {
     /**
      * @dev The hToken to be set is not the Hop L2 amm hToken
      */
-    error TaskHopTokenAmmMismatch(address hToken, address amm, address hopL2AmmHToken);    
+    error TaskHopTokenAmmMismatch(address hToken, address amm, address hopL2AmmHToken);
 
     /**
      * @dev Emitted every time an AMM is set for a token

--- a/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
@@ -21,6 +21,21 @@ import './IBaseSwapTask.sol';
  */
 interface IParaswapV5Swapper is IBaseSwapTask {
     /**
+     * @dev The signer to be set is not the quote signer
+     */
+    error TaskInvalidQuoteSigner(address signer, address quoteSigner);
+
+    /**
+     * @dev The deadline is in the past
+     */
+    error TaskQuoteSignerDeadline(uint256 deadline);
+
+    /**
+     * @dev The quote signer is zero
+     */
+    error TaskQuoteSignerZero();
+
+    /**
      * @dev Emitted every time a quote signer is set
      */
     event QuoteSignerSet(address indexed quoteSigner);

--- a/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
@@ -28,7 +28,7 @@ interface IParaswapV5Swapper is IBaseSwapTask {
     /**
      * @dev The deadline is in the past
      */
-    error TaskQuoteSignerDeadline(uint256 deadline);
+    error TaskQuoteSignerPastDeadline(uint256 deadline, uint256 now);
 
     /**
      * @dev The quote signer is zero

--- a/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IParaswapV5Swapper.sol
@@ -21,6 +21,11 @@ import './IBaseSwapTask.sol';
  */
 interface IParaswapV5Swapper is IBaseSwapTask {
     /**
+     * @dev The quote signer is zero
+     */
+    error TaskQuoteSignerZero();
+
+    /**
      * @dev The signer to be set is not the quote signer
      */
     error TaskInvalidQuoteSigner(address signer, address quoteSigner);
@@ -28,12 +33,7 @@ interface IParaswapV5Swapper is IBaseSwapTask {
     /**
      * @dev The deadline is in the past
      */
-    error TaskQuoteSignerPastDeadline(uint256 deadline, uint256 now);
-
-    /**
-     * @dev The quote signer is zero
-     */
-    error TaskQuoteSignerZero();
+    error TaskQuoteSignerPastDeadline(uint256 deadline, uint256 currentTimestamp);
 
     /**
      * @dev Emitted every time a quote signer is set

--- a/packages/tasks/contracts/liquidity/convex/BaseConvexTask.sol
+++ b/packages/tasks/contracts/liquidity/convex/BaseConvexTask.sol
@@ -63,7 +63,7 @@ abstract contract BaseConvexTask is IBaseConvexTask, Task {
      */
     function _beforeBaseConvexTask(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
     }
 
     /**
@@ -78,7 +78,7 @@ abstract contract BaseConvexTask is IBaseConvexTask, Task {
      * @param newConnector New connector to be set
      */
     function _setConnector(address newConnector) internal {
-        require(newConnector != address(0), 'TASK_CONNECTOR_ZERO');
+        if (newConnector == address(0)) revert TaskConnectorZero();
         connector = newConnector;
         emit ConnectorSet(newConnector);
     }

--- a/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
+++ b/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
@@ -91,7 +91,7 @@ contract ConvexClaimer is IConvexClaimer, BaseConvexTask {
      */
     function _beforeConvexClaimer(address token, uint256 amount) internal virtual {
         _beforeBaseConvexTask(token, amount);
-        require(amount == 0, 'TASK_AMOUNT_NOT_ZERO');
+        if (amount != 0) revert TaskAmountNotZero();
     }
 
     /**
@@ -103,7 +103,7 @@ contract ConvexClaimer is IConvexClaimer, BaseConvexTask {
         address[] memory tokensOut,
         uint256[] memory amountsOut
     ) internal virtual {
-        require(tokensOut.length == amountsOut.length, 'CLAIMER_INVALID_RESULT_LEN');
+        if (tokensOut.length != amountsOut.length) revert ClaimerInvalidResultLength(tokensOut.length, amountsOut.length);
         for (uint256 i = 0; i < tokensOut.length; i++) _increaseBalanceConnector(tokensOut[i], amountsOut[i]);
         _afterBaseConvexTask(tokenIn, amountIn);
     }
@@ -114,7 +114,7 @@ contract ConvexClaimer is IConvexClaimer, BaseConvexTask {
      * @param next Balance connector id of the next task in the workflow
      */
     function _setBalanceConnectors(bytes32 previous, bytes32 next) internal virtual override {
-        require(previous == bytes32(0), 'TASK_PREVIOUS_CONNECTOR_NOT_ZERO');
+        if (previous != bytes32(0)) revert TaskPreviousConnectorNotZero(previous);
         super._setBalanceConnectors(previous, next);
     }
 }

--- a/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
+++ b/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
@@ -103,8 +103,7 @@ contract ConvexClaimer is IConvexClaimer, BaseConvexTask {
         address[] memory tokensOut,
         uint256[] memory amountsOut
     ) internal virtual {
-        if (tokensOut.length != amountsOut.length)
-            revert ClaimerInvalidResultLength(tokensOut.length, amountsOut.length);
+        if (tokensOut.length != amountsOut.length) revert TaskClaimResultLengthMismatch();
         for (uint256 i = 0; i < tokensOut.length; i++) _increaseBalanceConnector(tokensOut[i], amountsOut[i]);
         _afterBaseConvexTask(tokenIn, amountIn);
     }

--- a/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
+++ b/packages/tasks/contracts/liquidity/convex/ConvexClaimer.sol
@@ -103,7 +103,8 @@ contract ConvexClaimer is IConvexClaimer, BaseConvexTask {
         address[] memory tokensOut,
         uint256[] memory amountsOut
     ) internal virtual {
-        if (tokensOut.length != amountsOut.length) revert ClaimerInvalidResultLength(tokensOut.length, amountsOut.length);
+        if (tokensOut.length != amountsOut.length)
+            revert ClaimerInvalidResultLength(tokensOut.length, amountsOut.length);
         for (uint256 i = 0; i < tokensOut.length; i++) _increaseBalanceConnector(tokensOut[i], amountsOut[i]);
         _afterBaseConvexTask(tokenIn, amountIn);
     }

--- a/packages/tasks/contracts/liquidity/convex/ConvexExiter.sol
+++ b/packages/tasks/contracts/liquidity/convex/ConvexExiter.sol
@@ -79,7 +79,7 @@ contract ConvexExiter is IConvexExiter, BaseConvexTask {
      */
     function _beforeConvexExiter(address token, uint256 amount) internal virtual {
         _beforeBaseConvexTask(token, amount);
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**

--- a/packages/tasks/contracts/liquidity/convex/ConvexJoiner.sol
+++ b/packages/tasks/contracts/liquidity/convex/ConvexJoiner.sol
@@ -79,7 +79,7 @@ contract ConvexJoiner is IConvexJoiner, BaseConvexTask {
      */
     function _beforeConvexJoiner(address token, uint256 amount) internal virtual {
         _beforeBaseConvexTask(token, amount);
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**

--- a/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
+++ b/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
@@ -164,7 +164,7 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
         if (amount == 0) revert TaskAmountZero();
         if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
         uint256 maxSlippage = getMaxSlippage(token);
-        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
+        if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }
 
     /**

--- a/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
+++ b/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
@@ -160,10 +160,11 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
      */
     function _beforeBaseCurveTask(address token, uint256 amount, uint256 slippage) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
-        require(getTokenOut(token) != address(0), 'TASK_TOKEN_OUT_NOT_SET');
-        require(slippage <= getMaxSlippage(token), 'TASK_SLIPPAGE_TOO_HIGH');
+        if (token == address(0)) revert TaskTokenZero();
+        if (amount == 0) revert TaskAmountZero();
+        if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
+        uint256 maxSlippage = getMaxSlippage(token);
+        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
     }
 
     /**
@@ -182,7 +183,7 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
      * @param newConnector New connector to be set
      */
     function _setConnector(address newConnector) internal {
-        require(newConnector != address(0), 'TASK_CONNECTOR_ZERO');
+        if (newConnector == address(0)) revert TaskConnectorZero();
         connector = newConnector;
         emit ConnectorSet(newConnector);
     }
@@ -201,7 +202,7 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
      * @param maxSlippage Default max slippage to be set
      */
     function _setDefaultMaxSlippage(uint256 maxSlippage) internal {
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         defaultMaxSlippage = maxSlippage;
         emit DefaultMaxSlippageSet(maxSlippage);
     }
@@ -212,7 +213,7 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
      * @param tokenOut Address of the token out to be set
      */
     function _setCustomTokenOut(address token, address tokenOut) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
         customTokenOut[token] = tokenOut;
         emit CustomTokenOutSet(token, tokenOut);
     }
@@ -223,8 +224,8 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
      * @param maxSlippage Max slippage to be set
      */
     function _setCustomMaxSlippage(address token, uint256 maxSlippage) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (token == address(0)) revert TaskTokenZero();
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         customMaxSlippage[token] = maxSlippage;
         emit CustomMaxSlippageSet(token, maxSlippage);
     }

--- a/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
+++ b/packages/tasks/contracts/liquidity/curve/BaseCurveTask.sol
@@ -163,6 +163,7 @@ abstract contract BaseCurveTask is IBaseCurveTask, Task {
         if (token == address(0)) revert TaskTokenZero();
         if (amount == 0) revert TaskAmountZero();
         if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
+
         uint256 maxSlippage = getMaxSlippage(token);
         if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }

--- a/packages/tasks/contracts/primitives/Collector.sol
+++ b/packages/tasks/contracts/primitives/Collector.sol
@@ -92,8 +92,8 @@ contract Collector is ICollector, Task {
      */
     function _beforeCollector(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**
@@ -110,7 +110,7 @@ contract Collector is ICollector, Task {
      * @param next Balance connector id of the next task in the workflow
      */
     function _setBalanceConnectors(bytes32 previous, bytes32 next) internal virtual override {
-        require(previous == bytes32(0), 'TASK_PREVIOUS_CONNECTOR_NOT_ZERO');
+        if (previous != bytes32(0)) revert TaskPreviousConnectorNotZero(previous);
         super._setBalanceConnectors(previous, next);
     }
 
@@ -119,7 +119,7 @@ contract Collector is ICollector, Task {
      * @param tokensSource Address of the tokens source to be set
      */
     function _setTokensSource(address tokensSource) internal virtual {
-        require(tokensSource != address(0), 'TASK_TOKENS_SOURCE_ZERO');
+        if (tokensSource == address(0)) revert TaskTokensSourceZero();
         _tokensSource = tokensSource;
         emit TokensSourceSet(tokensSource);
     }

--- a/packages/tasks/contracts/primitives/Depositor.sol
+++ b/packages/tasks/contracts/primitives/Depositor.sol
@@ -31,6 +31,11 @@ contract Depositor is ICollector, Collector {
     using SafeERC20 for IERC20;
 
     /**
+     * @dev The tokens source to be set is not the contract itself
+     */
+    error TaskDepositBadTokensSource(address tokensSource, address thisAddress);
+
+    /**
      * @dev It allows receiving native token transfers
      */
     receive() external payable {
@@ -60,7 +65,7 @@ contract Depositor is ICollector, Collector {
      * @param tokensSource Address of the tokens source to be set
      */
     function _setTokensSource(address tokensSource) internal override {
-        require(tokensSource == address(this), 'TASK_DEPOSITOR_BAD_TOKENS_SOURCE');
+        if (tokensSource != address(this)) revert TaskDepositBadTokensSource(tokensSource, address(this));
         super._setTokensSource(tokensSource);
     }
 }

--- a/packages/tasks/contracts/primitives/Depositor.sol
+++ b/packages/tasks/contracts/primitives/Depositor.sol
@@ -33,7 +33,7 @@ contract Depositor is ICollector, Collector {
     /**
      * @dev The tokens source to be set is not the contract itself
      */
-    error TaskDepositBadTokensSource(address tokensSource, address thisAddress);
+    error TaskDepositorBadTokensSource(address tokensSource, address thisAddress);
 
     /**
      * @dev It allows receiving native token transfers
@@ -65,7 +65,7 @@ contract Depositor is ICollector, Collector {
      * @param tokensSource Address of the tokens source to be set
      */
     function _setTokensSource(address tokensSource) internal override {
-        if (tokensSource != address(this)) revert TaskDepositBadTokensSource(tokensSource, address(this));
+        if (tokensSource != address(this)) revert TaskDepositorBadTokensSource(tokensSource, address(this));
         super._setTokensSource(tokensSource);
     }
 }

--- a/packages/tasks/contracts/primitives/Depositor.sol
+++ b/packages/tasks/contracts/primitives/Depositor.sol
@@ -33,7 +33,7 @@ contract Depositor is ICollector, Collector {
     /**
      * @dev The tokens source to be set is not the contract itself
      */
-    error TaskDepositorBadTokensSource(address tokensSource, address thisAddress);
+    error TaskDepositorBadTokensSource(address tokensSource);
 
     /**
      * @dev It allows receiving native token transfers
@@ -65,7 +65,7 @@ contract Depositor is ICollector, Collector {
      * @param tokensSource Address of the tokens source to be set
      */
     function _setTokensSource(address tokensSource) internal override {
-        if (tokensSource != address(this)) revert TaskDepositorBadTokensSource(tokensSource, address(this));
+        if (tokensSource != address(this)) revert TaskDepositorBadTokensSource(tokensSource);
         super._setTokensSource(tokensSource);
     }
 }

--- a/packages/tasks/contracts/primitives/Unwrapper.sol
+++ b/packages/tasks/contracts/primitives/Unwrapper.sol
@@ -72,8 +72,8 @@ contract Unwrapper is IUnwrapper, Task {
      */
     function _beforeUnwrapper(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(token == _wrappedNativeToken(), 'TASK_TOKEN_NOT_WRAPPED');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (token != _wrappedNativeToken()) revert TaskTokenNotWrapped();
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**

--- a/packages/tasks/contracts/primitives/Withdrawer.sol
+++ b/packages/tasks/contracts/primitives/Withdrawer.sol
@@ -83,8 +83,8 @@ contract Withdrawer is IWithdrawer, Task {
      */
     function _beforeWithdrawer(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**
@@ -99,8 +99,8 @@ contract Withdrawer is IWithdrawer, Task {
      * @param newRecipient Address of the new recipient to be set
      */
     function _setRecipient(address newRecipient) internal {
-        require(newRecipient != address(0), 'TASK_RECIPIENT_ZERO');
-        require(newRecipient != smartVault, 'TASK_RECIPIENT_SMART_VAULT');
+        if (newRecipient == address(0)) revert TaskRecipientZero();
+        if (newRecipient == smartVault) revert TaskRecipientSmartVault(newRecipient);
         recipient = newRecipient;
         emit RecipientSet(newRecipient);
     }
@@ -111,7 +111,7 @@ contract Withdrawer is IWithdrawer, Task {
      * @param next Balance connector id of the next task in the workflow
      */
     function _setBalanceConnectors(bytes32 previous, bytes32 next) internal virtual override {
-        require(next == bytes32(0), 'TASK_NEXT_CONNECTOR_NOT_ZERO');
+        if (next != bytes32(0)) revert TaskNextConnectorNotZero(next);
         super._setBalanceConnectors(previous, next);
     }
 }

--- a/packages/tasks/contracts/primitives/Withdrawer.sol
+++ b/packages/tasks/contracts/primitives/Withdrawer.sol
@@ -100,7 +100,7 @@ contract Withdrawer is IWithdrawer, Task {
      */
     function _setRecipient(address newRecipient) internal {
         if (newRecipient == address(0)) revert TaskRecipientZero();
-        if (newRecipient == smartVault) revert TaskRecipientSmartVault(newRecipient);
+        if (newRecipient == smartVault) revert TaskRecipientEqualsSmartVault(newRecipient);
         recipient = newRecipient;
         emit RecipientSet(newRecipient);
     }

--- a/packages/tasks/contracts/primitives/Wrapper.sol
+++ b/packages/tasks/contracts/primitives/Wrapper.sol
@@ -73,8 +73,8 @@ contract Wrapper is IWrapper, Task {
      */
     function _beforeWrapper(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(token == Denominations.NATIVE_TOKEN, 'TASK_TOKEN_NOT_NATIVE');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (token != Denominations.NATIVE_TOKEN) revert TaskTokenNotNative();
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**

--- a/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
+++ b/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
@@ -86,15 +86,12 @@ abstract contract BaseRelayerFundTask is IBaseRelayerFundTask, Task {
         uint256 depositedInThresholdToken = _getDepositedInThresholdToken(threshold.token);
         uint256 usedQuotaInThresholdToken = _getUsedQuotaInThresholdToken(threshold.token);
 
-        if (depositedInThresholdToken >= threshold.min + usedQuotaInThresholdToken)
-            revert TaskDepositedAboveMinThreshold(depositedInThresholdToken, threshold.min, usedQuotaInThresholdToken);
-        if (amountInThresholdToken + depositedInThresholdToken > threshold.max + usedQuotaInThresholdToken)
-            revert TaskAmountAboveMaxThreshold(
-                amountInThresholdToken,
-                depositedInThresholdToken,
-                threshold.max,
-                usedQuotaInThresholdToken
-            );
+        bool isAboveMin = depositedInThresholdToken >= threshold.min + usedQuotaInThresholdToken;
+        if (isAboveMin) revert TaskDepositAboveMinThreshold(depositedInThresholdToken, threshold.min);
+
+        uint256 newBalance = amountInThresholdToken + depositedInThresholdToken;
+        bool isAboveMax = newBalance > threshold.max + usedQuotaInThresholdToken;
+        if (isAboveMax) revert TaskDepositAboveMaxThreshold(newBalance, threshold.max, usedQuotaInThresholdToken);
     }
 
     /**

--- a/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
+++ b/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
@@ -89,7 +89,12 @@ abstract contract BaseRelayerFundTask is IBaseRelayerFundTask, Task {
         if (depositedInThresholdToken >= threshold.min + usedQuotaInThresholdToken)
             revert TaskDepositedAboveMinThreshold(depositedInThresholdToken, threshold.min, usedQuotaInThresholdToken);
         if (amountInThresholdToken + depositedInThresholdToken > threshold.max + usedQuotaInThresholdToken)
-            revert TaskAmountAboveMaxThreshold(amountInThresholdToken, depositedInThresholdToken, threshold.max, usedQuotaInThresholdToken);
+            revert TaskAmountAboveMaxThreshold(
+                amountInThresholdToken,
+                depositedInThresholdToken,
+                threshold.max,
+                usedQuotaInThresholdToken
+            );
     }
 
     /**

--- a/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
+++ b/packages/tasks/contracts/relayer/BaseRelayerFundTask.sol
@@ -86,11 +86,10 @@ abstract contract BaseRelayerFundTask is IBaseRelayerFundTask, Task {
         uint256 depositedInThresholdToken = _getDepositedInThresholdToken(threshold.token);
         uint256 usedQuotaInThresholdToken = _getUsedQuotaInThresholdToken(threshold.token);
 
-        require(depositedInThresholdToken < threshold.min + usedQuotaInThresholdToken, 'TASK_TOKEN_THRESHOLD_NOT_MET');
-        require(
-            amountInThresholdToken + depositedInThresholdToken <= threshold.max + usedQuotaInThresholdToken,
-            'TASK_AMOUNT_ABOVE_THRESHOLD'
-        );
+        if (depositedInThresholdToken >= threshold.min + usedQuotaInThresholdToken)
+            revert TaskDepositedAboveMinThreshold(depositedInThresholdToken, threshold.min, usedQuotaInThresholdToken);
+        if (amountInThresholdToken + depositedInThresholdToken > threshold.max + usedQuotaInThresholdToken)
+            revert TaskAmountAboveMaxThreshold(amountInThresholdToken, depositedInThresholdToken, threshold.max, usedQuotaInThresholdToken);
     }
 
     /**
@@ -116,7 +115,7 @@ abstract contract BaseRelayerFundTask is IBaseRelayerFundTask, Task {
      * @param newRelayer Address of the relayer to be set
      */
     function _setRelayer(address newRelayer) internal {
-        require(newRelayer != address(0), 'TASK_FUNDER_RELAYER_ZERO');
+        if (newRelayer == address(0)) revert TaskRelayerZero();
         relayer = newRelayer;
         emit RelayerSet(newRelayer);
     }

--- a/packages/tasks/contracts/relayer/CollectorRelayerFunder.sol
+++ b/packages/tasks/contracts/relayer/CollectorRelayerFunder.sol
@@ -26,7 +26,7 @@ contract CollectorRelayerFunder is BaseRelayerFundTask, Collector {
      * @dev Disables the default collector initializer
      */
     function initialize(CollectConfig memory) external pure override {
-        revert('COLLECTOR_INITIALIZER_DISABLED');
+        revert TaskInitializerDisabled();
     }
 
     /**

--- a/packages/tasks/contracts/relayer/OneInchV5RelayerFunder.sol
+++ b/packages/tasks/contracts/relayer/OneInchV5RelayerFunder.sol
@@ -26,7 +26,7 @@ contract OneInchV5RelayerFunder is BaseRelayerFundTask, OneInchV5Swapper {
      * @dev Disables the default 1inch v5 swapper initializer
      */
     function initialize(OneInchV5SwapConfig memory) external pure override {
-        revert('SWAPPER_INITIALIZER_DISABLED');
+        revert TaskInitializerDisabled();
     }
 
     /**

--- a/packages/tasks/contracts/relayer/RelayerDepositor.sol
+++ b/packages/tasks/contracts/relayer/RelayerDepositor.sol
@@ -90,7 +90,7 @@ contract RelayerDepositor is IRelayerDepositor, Task {
      */
     function _beforeRelayerDepositor(address token, uint256 amount) internal virtual {
         _beforeTask(token, amount);
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
+        if (amount == 0) revert TaskAmountZero();
     }
 
     /**
@@ -105,7 +105,7 @@ contract RelayerDepositor is IRelayerDepositor, Task {
      * @param newRelayer Address of the relayer to be set
      */
     function _setRelayer(address newRelayer) internal {
-        require(newRelayer != address(0), 'TASK_RELAYER_DEPOSITOR_ZERO');
+        if (newRelayer == address(0)) revert TaskRelayerZero();
         relayer = newRelayer;
         emit RelayerSet(newRelayer);
     }

--- a/packages/tasks/contracts/relayer/UnwrapperRelayerFunder.sol
+++ b/packages/tasks/contracts/relayer/UnwrapperRelayerFunder.sol
@@ -26,7 +26,7 @@ contract UnwrapperRelayerFunder is BaseRelayerFundTask, Unwrapper {
      * @dev Disables the default unwrapper initializer
      */
     function initialize(UnwrapConfig memory) external pure override {
-        revert('UNWRAPPER_INITIALIZER_DISABLED');
+        revert TaskInitializerDisabled();
     }
 
     /**

--- a/packages/tasks/contracts/swap/BaseSwapTask.sol
+++ b/packages/tasks/contracts/swap/BaseSwapTask.sol
@@ -167,6 +167,7 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
         if (token == address(0)) revert TaskTokenZero();
         if (amount == 0) revert TaskAmountZero();
         if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
+
         uint256 maxSlippage = getMaxSlippage(token);
         if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }

--- a/packages/tasks/contracts/swap/BaseSwapTask.sol
+++ b/packages/tasks/contracts/swap/BaseSwapTask.sol
@@ -168,7 +168,7 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
         if (amount == 0) revert TaskAmountZero();
         if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
         uint256 maxSlippage = getMaxSlippage(token);
-        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
+        if (slippage > maxSlippage) revert TaskSlippageAboveMax(slippage, maxSlippage);
     }
 
     /**

--- a/packages/tasks/contracts/swap/BaseSwapTask.sol
+++ b/packages/tasks/contracts/swap/BaseSwapTask.sol
@@ -164,10 +164,11 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
      */
     function _beforeBaseSwapTask(address token, uint256 amount, uint256 slippage) internal virtual {
         _beforeTask(token, amount);
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(amount > 0, 'TASK_AMOUNT_ZERO');
-        require(getTokenOut(token) != address(0), 'TASK_TOKEN_OUT_NOT_SET');
-        require(slippage <= getMaxSlippage(token), 'TASK_SLIPPAGE_TOO_HIGH');
+        if (token == address(0)) revert TaskTokenZero();
+        if (amount == 0) revert TaskAmountZero();
+        if (getTokenOut(token) == address(0)) revert TaskTokenOutNotSet();
+        uint256 maxSlippage = getMaxSlippage(token);
+        if (slippage > maxSlippage) revert TaskSlippageTooHigh(slippage, maxSlippage);
     }
 
     /**
@@ -186,7 +187,7 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
      * @param newConnector Address of the connector to be set
      */
     function _setConnector(address newConnector) internal {
-        require(newConnector != address(0), 'TASK_CONNECTOR_ZERO');
+        if (newConnector == address(0)) revert TaskConnectorZero();
         connector = newConnector;
         emit ConnectorSet(newConnector);
     }
@@ -205,7 +206,7 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
      * @param maxSlippage Default max slippage to be set
      */
     function _setDefaultMaxSlippage(uint256 maxSlippage) internal {
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         defaultMaxSlippage = maxSlippage;
         emit DefaultMaxSlippageSet(maxSlippage);
     }
@@ -216,7 +217,7 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
      * @param tokenOut Address of the token out to be set
      */
     function _setCustomTokenOut(address token, address tokenOut) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
+        if (token == address(0)) revert TaskTokenZero();
         customTokenOut[token] = tokenOut;
         emit CustomTokenOutSet(token, tokenOut);
     }
@@ -227,8 +228,8 @@ abstract contract BaseSwapTask is IBaseSwapTask, Task {
      * @param maxSlippage Max slippage to be set
      */
     function _setCustomMaxSlippage(address token, uint256 maxSlippage) internal {
-        require(token != address(0), 'TASK_TOKEN_ZERO');
-        require(maxSlippage <= FixedPoint.ONE, 'TASK_SLIPPAGE_ABOVE_ONE');
+        if (token == address(0)) revert TaskTokenZero();
+        if (maxSlippage > FixedPoint.ONE) revert TaskSlippageAboveOne();
         customMaxSlippage[token] = maxSlippage;
         emit CustomMaxSlippageSet(token, maxSlippage);
     }

--- a/packages/tasks/contracts/swap/HopL2Swapper.sol
+++ b/packages/tasks/contracts/swap/HopL2Swapper.sol
@@ -117,7 +117,7 @@ contract HopL2Swapper is IHopL2Swapper, BaseSwapTask {
      */
     function _beforeHopL2Swapper(address token, uint256 amount, uint256 slippage) internal virtual {
         _beforeBaseSwapTask(token, amount, slippage);
-        require(tokenAmm[token] != address(0), 'TASK_MISSING_HOP_TOKEN_AMM');
+        if (tokenAmm[token] == address(0)) revert TaskMissingHopTokenAmm();
     }
 
     /**
@@ -139,8 +139,9 @@ contract HopL2Swapper is IHopL2Swapper, BaseSwapTask {
      * @param amm AMM to be set
      */
     function _setTokenAmm(address hToken, address amm) internal {
-        require(hToken != address(0), 'TASK_HOP_TOKEN_ZERO');
-        require(amm == address(0) || hToken == IHopL2Amm(amm).hToken(), 'TASK_HOP_TOKEN_AMM_MISMATCH');
+        if (hToken == address(0)) revert TaskTokenZero();
+        address hopL2AmmHToken = IHopL2Amm(amm).hToken();
+        if (amm != address(0) && hToken != hopL2AmmHToken) revert TaskHopTokenAmmMismatch(hToken, amm, hopL2AmmHToken);
 
         tokenAmm[hToken] = amm;
         emit TokenAmmSet(hToken, amm);

--- a/packages/tasks/contracts/swap/HopL2Swapper.sol
+++ b/packages/tasks/contracts/swap/HopL2Swapper.sol
@@ -140,8 +140,7 @@ contract HopL2Swapper is IHopL2Swapper, BaseSwapTask {
      */
     function _setTokenAmm(address hToken, address amm) internal {
         if (hToken == address(0)) revert TaskTokenZero();
-        address hopL2AmmHToken = IHopL2Amm(amm).hToken();
-        if (amm != address(0) && hToken != hopL2AmmHToken) revert TaskHopTokenAmmMismatch(hToken, amm, hopL2AmmHToken);
+        if (amm != address(0) && hToken != IHopL2Amm(amm).hToken()) revert TaskHopTokenAmmMismatch(hToken, amm);
 
         tokenAmm[hToken] = amm;
         emit TokenAmmSet(hToken, amm);

--- a/packages/tasks/contracts/swap/ParaswapV5Swapper.sol
+++ b/packages/tasks/contracts/swap/ParaswapV5Swapper.sol
@@ -137,8 +137,8 @@ contract ParaswapV5Swapper is IParaswapV5Swapper, BaseSwapTask {
             abi.encodePacked(tokenIn, tokenOut, isBuy, amountIn, minAmountOut, expectedAmountOut, deadline, data)
         );
         address signer = ECDSA.recover(ECDSA.toEthSignedMessageHash(message), sig);
-        require(signer == quoteSigner, 'TASK_INVALID_QUOTE_SIGNER');
-        require(block.timestamp <= deadline, 'TASK_QUOTE_SIGNER_DEADLINE');
+        if (signer != quoteSigner) revert TaskInvalidQuoteSigner(signer, quoteSigner);
+        if (block.timestamp > deadline) revert TaskQuoteSignerDeadline(deadline);
     }
 
     /**
@@ -159,7 +159,7 @@ contract ParaswapV5Swapper is IParaswapV5Swapper, BaseSwapTask {
      * @param newQuoteSigner Address of the new quote signer to be set
      */
     function _setQuoteSigner(address newQuoteSigner) internal {
-        require(newQuoteSigner != address(0), 'TASK_QUOTE_SIGNER_ZERO');
+        if (newQuoteSigner == address(0)) revert TaskQuoteSignerZero();
         quoteSigner = newQuoteSigner;
         emit QuoteSignerSet(newQuoteSigner);
     }

--- a/packages/tasks/contracts/swap/ParaswapV5Swapper.sol
+++ b/packages/tasks/contracts/swap/ParaswapV5Swapper.sol
@@ -138,7 +138,7 @@ contract ParaswapV5Swapper is IParaswapV5Swapper, BaseSwapTask {
         );
         address signer = ECDSA.recover(ECDSA.toEthSignedMessageHash(message), sig);
         if (signer != quoteSigner) revert TaskInvalidQuoteSigner(signer, quoteSigner);
-        if (block.timestamp > deadline) revert TaskQuoteSignerDeadline(deadline);
+        if (block.timestamp > deadline) revert TaskQuoteSignerPastDeadline(deadline, block.timestamp);
     }
 
     /**

--- a/packages/tasks/test/base/BaseTask.test.ts
+++ b/packages/tasks/test/base/BaseTask.test.ts
@@ -157,7 +157,7 @@ describe('BaseTask', () => {
           const next = '0x0000000000000000000000000000000000000000000000000000000000000001'
 
           it('reverts', async () => {
-            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith('TASK_SAME_BALANCE_CONNECTORS')
+            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith('TaskSameBalanceConnectors')
           })
         })
       })
@@ -172,9 +172,7 @@ describe('BaseTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -223,7 +221,7 @@ describe('BaseTask', () => {
 
       context('when there is not enough balance in the connector', () => {
         it('reverts', async () => {
-          await expect(task.call(token, amount)).to.be.revertedWith('SMART_VAULT_CONNECTOR_NO_BALANCE')
+          await expect(task.call(token, amount)).to.be.reverted
         })
       })
     })

--- a/packages/tasks/test/base/GasLimitedTask.test.ts
+++ b/packages/tasks/test/base/GasLimitedTask.test.ts
@@ -268,7 +268,7 @@ describe('GasLimitedTask', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskTxCostLimit')
+            await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskTxCostLimitExceeded')
           })
         })
       })
@@ -291,7 +291,9 @@ describe('GasLimitedTask', () => {
 
         context('when the tx moves less than the cost limit percentage', () => {
           it('reverts', async () => {
-            await expect(task.call(NATIVE_TOKEN_ADDRESS, 1, { gasPrice })).to.be.revertedWith('TaskTxCostLimitPct')
+            await expect(task.call(NATIVE_TOKEN_ADDRESS, 1, { gasPrice })).to.be.revertedWith(
+              'TaskTxCostLimitPctExceeded'
+            )
           })
         })
       })
@@ -310,7 +312,7 @@ describe('GasLimitedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimit')
+          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimitExceeded')
         })
       })
 
@@ -324,7 +326,7 @@ describe('GasLimitedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimit')
+          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimitExceeded')
         })
       })
     })

--- a/packages/tasks/test/base/GasLimitedTask.test.ts
+++ b/packages/tasks/test/base/GasLimitedTask.test.ts
@@ -14,6 +14,8 @@ import { Contract } from 'ethers'
 
 import { deployEnvironment } from '../../src/setup'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('GasLimitedTask', () => {
   let task: Contract
   let smartVault: Contract, authorizer: Contract, owner: SignerWithAddress
@@ -85,7 +87,7 @@ describe('GasLimitedTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setGasPriceLimit(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setGasPriceLimit(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -129,7 +131,7 @@ describe('GasLimitedTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setPriorityFeeLimit(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setPriorityFeeLimit(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -173,7 +175,7 @@ describe('GasLimitedTask', () => {
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(task.setTxCostLimit(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTxCostLimit(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -216,14 +218,14 @@ describe('GasLimitedTask', () => {
         const txCostLimitPct = fp(1.1)
 
         it('reverts', async () => {
-          await expect(task.setTxCostLimitPct(txCostLimitPct)).to.be.revertedWith('TASK_TX_COST_LIMIT_PCT_ABOVE_ONE')
+          await expect(task.setTxCostLimitPct(txCostLimitPct)).to.be.revertedWith('TaskTxCostLimitPctAboveOne')
         })
       })
     })
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(task.setTxCostLimitPct(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTxCostLimitPct(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -266,7 +268,7 @@ describe('GasLimitedTask', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TASK_TX_COST_LIMIT')
+            await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskTxCostLimit')
           })
         })
       })
@@ -289,7 +291,7 @@ describe('GasLimitedTask', () => {
 
         context('when the tx moves less than the cost limit percentage', () => {
           it('reverts', async () => {
-            await expect(task.call(NATIVE_TOKEN_ADDRESS, 1, { gasPrice })).to.be.revertedWith('TASK_TX_COST_LIMIT_PCT')
+            await expect(task.call(NATIVE_TOKEN_ADDRESS, 1, { gasPrice })).to.be.revertedWith('TaskTxCostLimitPct')
           })
         })
       })
@@ -308,7 +310,7 @@ describe('GasLimitedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TASK_GAS_PRICE_LIMIT')
+          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimit')
         })
       })
 
@@ -322,7 +324,7 @@ describe('GasLimitedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TASK_GAS_PRICE_LIMIT')
+          await expect(task.call(ZERO_ADDRESS, 0, { gasPrice })).to.be.revertedWith('TaskGasPriceLimit')
         })
       })
     })

--- a/packages/tasks/test/base/PausableTask.test.ts
+++ b/packages/tasks/test/base/PausableTask.test.ts
@@ -55,14 +55,14 @@ describe('PausableTask', () => {
         })
 
         it('cannot be paused', async () => {
-          await expect(task.pause()).to.be.revertedWith('TASK_ALREADY_PAUSED')
+          await expect(task.pause()).to.be.revertedWith('TaskAlreadyPaused')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.pause()).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.pause()).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -77,7 +77,7 @@ describe('PausableTask', () => {
 
       context('when the task is not paused', () => {
         it('cannot be unpaused', async () => {
-          await expect(task.unpause()).to.be.revertedWith('TASK_ALREADY_UNPAUSED')
+          await expect(task.unpause()).to.be.revertedWith('TaskAlreadyUnpaused')
         })
       })
 
@@ -100,7 +100,7 @@ describe('PausableTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.unpause()).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.unpause()).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -124,7 +124,7 @@ describe('PausableTask', () => {
       })
 
       it('cannot be executed', async () => {
-        await expect(task.call(token, amount)).to.be.revertedWith('TASK_PAUSED')
+        await expect(task.call(token, amount)).to.be.revertedWith('TaskPaused')
       })
     })
   })

--- a/packages/tasks/test/base/PausableTask.test.ts
+++ b/packages/tasks/test/base/PausableTask.test.ts
@@ -55,7 +55,7 @@ describe('PausableTask', () => {
         })
 
         it('cannot be paused', async () => {
-          await expect(task.pause()).to.be.revertedWith('TaskAlreadyPaused')
+          await expect(task.pause()).to.be.revertedWith('TaskPaused')
         })
       })
     })
@@ -77,7 +77,7 @@ describe('PausableTask', () => {
 
       context('when the task is not paused', () => {
         it('cannot be unpaused', async () => {
-          await expect(task.unpause()).to.be.revertedWith('TaskAlreadyUnpaused')
+          await expect(task.unpause()).to.be.revertedWith('TaskUnpaused')
         })
       })
 

--- a/packages/tasks/test/base/TimeLockedTask.test.ts
+++ b/packages/tasks/test/base/TimeLockedTask.test.ts
@@ -16,6 +16,8 @@ import { BigNumber, Contract } from 'ethers'
 
 import { deployEnvironment } from '../../src/setup'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('TimeLockedTask', () => {
   let task: Contract
   let smartVault: Contract, authorizer: Contract, owner: SignerWithAddress
@@ -95,14 +97,14 @@ describe('TimeLockedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.setTimeLockDelay(delay)).to.be.revertedWith('TASK_DELAY_GT_EXECUTION_PERIOD')
+          await expect(task.setTimeLockDelay(delay)).to.be.revertedWith('TaskExecutionPeriodGtDelay')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTimeLockDelay(delay)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTimeLockDelay(delay)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -137,7 +139,7 @@ describe('TimeLockedTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTimeLockExpiration(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTimeLockExpiration(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -189,14 +191,14 @@ describe('TimeLockedTask', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.setTimeLockExecutionPeriod(period)).to.be.revertedWith('TASK_EXECUTION_PERIOD_GT_DELAY')
+          await expect(task.setTimeLockExecutionPeriod(period)).to.be.revertedWith('TaskExecutionPeriodGtDelay')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTimeLockExecutionPeriod(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTimeLockExecutionPeriod(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -253,7 +255,7 @@ describe('TimeLockedTask', () => {
 
           const tx = await task.call()
           await assertEvent(tx, 'TimeLockExpirationSet')
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           const previousExpiration = await task.timeLockExpiration()
           await advanceTime(newTimeLockDelay)
@@ -284,7 +286,7 @@ describe('TimeLockedTask', () => {
 
         it('must wait to be valid again after the first execution', async () => {
           await task.call()
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           const previousExpiration = await task.timeLockExpiration()
           await advanceTime(delay)
@@ -359,7 +361,7 @@ describe('TimeLockedTask', () => {
           const initialDelay = await task.timeLockDelay()
           const initialExpiration = await task.timeLockExpiration()
 
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           await advanceTime(initialExpirationTimestamp)
           const tx = await task.call()
@@ -404,7 +406,7 @@ describe('TimeLockedTask', () => {
         })
 
         it('can be validated once right after the initial delay', async () => {
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           await setNextBlockTimestamp(initialExpirationTimestamp)
           const tx = await task.call()
@@ -414,7 +416,7 @@ describe('TimeLockedTask', () => {
           expect(await task.timeLockExpiration()).to.be.equal(initialExpirationTimestamp.add(delay))
           expect(await task.timeLockExecutionPeriod()).to.be.equal(executionPeriod)
 
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           await setNextBlockTimestamp(initialExpirationTimestamp.add(delay * 2).add(executionPeriod))
           const tx2 = await task.call()
@@ -426,10 +428,10 @@ describe('TimeLockedTask', () => {
         })
 
         it('cannot be validated after the execution period', async () => {
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
 
           await setNextBlockTimestamp(initialExpirationTimestamp.add(executionPeriod).add(1))
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_WAIT_NEXT_PERIOD')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockWaitNextPeriod')
 
           await setNextBlockTimestamp(initialExpirationTimestamp.add(delay))
           const tx = await task.call()
@@ -439,7 +441,7 @@ describe('TimeLockedTask', () => {
           expect(await task.timeLockExpiration()).to.be.equal(initialExpirationTimestamp.add(delay * 2))
           expect(await task.timeLockExecutionPeriod()).to.be.equal(executionPeriod)
 
-          await expect(task.call()).to.be.revertedWith('TASK_TIME_LOCK_NOT_EXPIRED')
+          await expect(task.call()).to.be.revertedWith('TaskTimeLockNotExpired')
         })
 
         it('can be changed at any time in the future without affecting the previous expiration date', async () => {

--- a/packages/tasks/test/base/TokenIndexedTask.test.ts
+++ b/packages/tasks/test/base/TokenIndexedTask.test.ts
@@ -94,7 +94,7 @@ describe('TokenIndexedTask', () => {
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(task.setTokensAcceptanceType(0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTokensAcceptanceType(0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -170,7 +170,7 @@ describe('TokenIndexedTask', () => {
       context('when an address zero is given', () => {
         it('reverts', async () => {
           await expect(task.setTokensAcceptanceList([ZERO_ADDRESS], [true])).to.be.revertedWith(
-            'TASK_ACCEPTANCE_TOKEN_ZERO'
+            'TaskAcceptanceTokenZero'
           )
         })
       })
@@ -178,7 +178,7 @@ describe('TokenIndexedTask', () => {
 
     context('when the sender is not allowed', () => {
       it('reverts', async () => {
-        await expect(task.setTokensAcceptanceList([], [])).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTokensAcceptanceList([], [])).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -203,8 +203,8 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenB)).to.be.false
         expect(await task.isTokenAllowed(tokenC)).to.be.false
         await expect(task.call(tokenA)).not.to.be.reverted
-        await expect(task.call(tokenB)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
-        await expect(task.call(tokenC)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenB)).to.be.revertedWith('TaskTokenNotAllowed')
+        await expect(task.call(tokenC)).to.be.revertedWith('TaskTokenNotAllowed')
 
         await task.connect(owner).setTokensAcceptanceList([tokenC], [true])
 
@@ -212,7 +212,7 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenB)).to.be.false
         expect(await task.isTokenAllowed(tokenC)).to.be.true
         await expect(task.call(tokenA)).not.to.be.reverted
-        await expect(task.call(tokenB)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenB)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenC)).not.to.be.reverted
 
         await task.connect(owner).setTokensAcceptanceList([tokenB], [true])
@@ -230,8 +230,8 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenA)).to.be.false
         expect(await task.isTokenAllowed(tokenB)).to.be.false
         expect(await task.isTokenAllowed(tokenC)).to.be.true
-        await expect(task.call(tokenA)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
-        await expect(task.call(tokenB)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenA)).to.be.revertedWith('TaskTokenNotAllowed')
+        await expect(task.call(tokenB)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenC)).not.to.be.reverted
 
         await task.connect(owner).setTokensAcceptanceType(TYPE.DENY_LIST)
@@ -240,9 +240,9 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenA)).to.be.false
         expect(await task.isTokenAllowed(tokenB)).to.be.true
         expect(await task.isTokenAllowed(tokenC)).to.be.false
-        await expect(task.call(tokenA)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenA)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenB)).not.to.be.reverted
-        await expect(task.call(tokenC)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenC)).to.be.revertedWith('TaskTokenNotAllowed')
       })
     })
 
@@ -259,7 +259,7 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenA)).to.be.false
         expect(await task.isTokenAllowed(tokenB)).to.be.true
         expect(await task.isTokenAllowed(tokenC)).to.be.true
-        await expect(task.call(tokenA)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenA)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenB)).not.to.be.reverted
         await expect(task.call(tokenC)).not.to.be.reverted
 
@@ -268,18 +268,18 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenA)).to.be.false
         expect(await task.isTokenAllowed(tokenB)).to.be.true
         expect(await task.isTokenAllowed(tokenC)).to.be.false
-        await expect(task.call(tokenA)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenA)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenB)).not.to.be.reverted
-        await expect(task.call(tokenC)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenC)).to.be.revertedWith('TaskTokenNotAllowed')
 
         await task.connect(owner).setTokensAcceptanceList([tokenB], [true])
 
         expect(await task.isTokenAllowed(tokenA)).to.be.false
         expect(await task.isTokenAllowed(tokenB)).to.be.false
         expect(await task.isTokenAllowed(tokenC)).to.be.false
-        await expect(task.call(tokenA)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
-        await expect(task.call(tokenB)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
-        await expect(task.call(tokenC)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenA)).to.be.revertedWith('TaskTokenNotAllowed')
+        await expect(task.call(tokenB)).to.be.revertedWith('TaskTokenNotAllowed')
+        await expect(task.call(tokenC)).to.be.revertedWith('TaskTokenNotAllowed')
 
         await task.connect(owner).setTokensAcceptanceList([tokenA], [false])
         await task.connect(owner).setTokensAcceptanceList([tokenB], [false])
@@ -289,7 +289,7 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenC)).to.be.false
         await expect(task.call(tokenA)).not.to.be.reverted
         await expect(task.call(tokenB)).not.to.be.reverted
-        await expect(task.call(tokenC)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenC)).to.be.revertedWith('TaskTokenNotAllowed')
 
         await task.connect(owner).setTokensAcceptanceType(TYPE.ALLOW_LIST)
         await task.connect(owner).setTokensAcceptanceList([tokenA, tokenB], [true, false])
@@ -298,7 +298,7 @@ describe('TokenIndexedTask', () => {
         expect(await task.isTokenAllowed(tokenB)).to.be.false
         expect(await task.isTokenAllowed(tokenC)).to.be.true
         await expect(task.call(tokenA)).not.to.be.reverted
-        await expect(task.call(tokenB)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+        await expect(task.call(tokenB)).to.be.revertedWith('TaskTokenNotAllowed')
         await expect(task.call(tokenC)).not.to.be.reverted
       })
     })

--- a/packages/tasks/test/base/TokenThresholdTask.test.ts
+++ b/packages/tasks/test/base/TokenThresholdTask.test.ts
@@ -123,7 +123,7 @@ describe('TokenThresholdTask', () => {
 
             it('reverts', async () => {
               await expect(task.setDefaultTokenThreshold(token, min, max)).to.be.revertedWith(
-                'TASK_INVALID_THRESHOLD_INPUT'
+                'TaskInvalidThresholdInput'
               )
             })
           })
@@ -133,7 +133,7 @@ describe('TokenThresholdTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setDefaultTokenThreshold(token, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setDefaultTokenThreshold(token, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -210,7 +210,7 @@ describe('TokenThresholdTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomTokenThreshold(token, thresholdToken, min, max)).to.be.revertedWith(
-                  'TASK_INVALID_THRESHOLD_INPUT'
+                  'TaskInvalidThresholdInput'
                 )
               })
             })
@@ -223,7 +223,7 @@ describe('TokenThresholdTask', () => {
 
         it('reverts', async () => {
           await expect(task.setCustomTokenThreshold(token, ZERO_ADDRESS, 0, 0)).to.be.revertedWith(
-            'TASK_THRESHOLD_TOKEN_ZERO'
+            'TaskThresholdTokenZero'
           )
         })
       })
@@ -232,7 +232,7 @@ describe('TokenThresholdTask', () => {
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
         await expect(task.setCustomTokenThreshold(ZERO_ADDRESS, ZERO_ADDRESS, 0, 0)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -252,7 +252,7 @@ describe('TokenThresholdTask', () => {
     }
 
     const assertInvalid = async (token: Contract | string, amount: BigNumberish) => {
-      await expect(task.call(token, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+      await expect(task.call(token, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
     }
 
     context('when there is no default threshold set', () => {

--- a/packages/tasks/test/base/VolumeLimitedTask.test.ts
+++ b/packages/tasks/test/base/VolumeLimitedTask.test.ts
@@ -112,7 +112,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -126,7 +126,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -136,7 +136,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -154,7 +154,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -164,7 +164,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -178,7 +178,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setDefaultVolumeLimit(token, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -308,7 +308,7 @@ describe('VolumeLimitedTask', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setDefaultVolumeLimit(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setDefaultVolumeLimit(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -376,7 +376,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -390,7 +390,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -400,7 +400,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -418,7 +418,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -428,7 +428,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -442,7 +442,7 @@ describe('VolumeLimitedTask', () => {
 
               it('reverts', async () => {
                 await expect(task.setCustomVolumeLimit(token.address, limitToken, amount, period)).to.be.revertedWith(
-                  'TASK_INVALID_VOLUME_LIMIT_INPUT'
+                  'TaskInvalidVolumeLimitInput'
                 )
               })
             })
@@ -584,7 +584,7 @@ describe('VolumeLimitedTask', () => {
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
         await expect(task.setCustomVolumeLimit(ZERO_ADDRESS, ZERO_ADDRESS, 0, 0)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -608,7 +608,7 @@ describe('VolumeLimitedTask', () => {
 
     const itCannotBeExecuted = () => {
       it('reverts', async () => {
-        await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_VOLUME_LIMIT_EXCEEDED')
+        await expect(task.call(token.address, amount)).to.be.revertedWith('TaskVolumeLimitExceeded')
       })
     }
 

--- a/packages/tasks/test/bridge/AxelarBridger.test.ts
+++ b/packages/tasks/test/bridge/AxelarBridger.test.ts
@@ -154,7 +154,7 @@ describe('AxelarBridger', () => {
                 })
 
                 it('reverts', async () => {
-                  await expect(task.call(token.address, amountIn)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+                  await expect(task.call(token.address, amountIn)).to.be.revertedWith('TaskTokenThresholdNotMet')
                 })
               })
             })
@@ -167,14 +167,14 @@ describe('AxelarBridger', () => {
               })
 
               it('reverts', async () => {
-                await expect(task.call(token.address, amountIn)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+                await expect(task.call(token.address, amountIn)).to.be.revertedWith('TaskTokenNotAllowed')
               })
             })
           })
 
           context('when the destination chain was not set', () => {
             it('reverts', async () => {
-              await expect(task.call(token.address, amountIn)).to.be.revertedWith('TASK_DESTINATION_CHAIN_NOT_SET')
+              await expect(task.call(token.address, amountIn)).to.be.revertedWith('TaskDestinationChainNotSet')
             })
           })
         })
@@ -183,7 +183,7 @@ describe('AxelarBridger', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -192,14 +192,14 @@ describe('AxelarBridger', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/bridge/BaseBridgeTask.behavior.ts
+++ b/packages/tasks/test/bridge/BaseBridgeTask.behavior.ts
@@ -45,9 +45,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
           const next = '0x0000000000000000000000000000000000000000000000000000000000000002'
 
           it('reverts', async function () {
-            await expect(this.task.setBalanceConnectors(previous, next)).to.be.revertedWith(
-              'TASK_NEXT_CONNECTOR_NOT_ZERO'
-            )
+            await expect(this.task.setBalanceConnectors(previous, next)).to.be.revertedWith('TaskNextConnectorNotZero')
           })
         })
       })
@@ -63,7 +61,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
         await expect(this.task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -101,14 +99,14 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
         const connector = ZERO_ADDRESS
 
         it('reverts', async function () {
-          await expect(this.task.setConnector(connector)).to.be.revertedWith('TASK_CONNECTOR_ZERO')
+          await expect(this.task.setConnector(connector)).to.be.revertedWith('TaskConnectorZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -139,14 +137,14 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
         const recipient = ZERO_ADDRESS
 
         it('reverts', async function () {
-          await expect(this.task.setRecipient(recipient)).to.be.revertedWith('TASK_RECIPIENT_ZERO')
+          await expect(this.task.setRecipient(recipient)).to.be.revertedWith('TaskRecipientZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setRecipient(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setRecipient(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -183,9 +181,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
             const chainId = 31337 // Hardhat destination chain
 
             it('reverts', async function () {
-              await expect(this.task.setDefaultDestinationChain(chainId)).to.be.revertedWith(
-                'TASK_BRIDGE_CURRENT_CHAIN_ID'
-              )
+              await expect(this.task.setDefaultDestinationChain(chainId)).to.be.revertedWith('TaskBridgeCurrentChainId')
             })
           })
         }
@@ -242,7 +238,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultDestinationChain(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultDestinationChain(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -304,7 +300,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
 
           it('reverts', async function () {
             await expect(this.task.setCustomDestinationChain(token.address, chainId)).to.be.revertedWith(
-              'TASK_BRIDGE_CURRENT_CHAIN_ID'
+              'TaskBridgeCurrentChainId'
             )
           })
         })
@@ -346,7 +342,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setCustomDestinationChain(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setCustomDestinationChain(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -381,14 +377,14 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
         const slippage = fp(1).add(1)
 
         it('reverts', async function () {
-          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TASK_SLIPPAGE_ABOVE_ONE')
+          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TaskSlippageAboveOne')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -430,7 +426,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
 
         it('reverts', async function () {
           await expect(this.task.setCustomMaxSlippage(token.address, slippage)).to.be.revertedWith(
-            'TASK_SLIPPAGE_ABOVE_ONE'
+            'TaskSlippageAboveOne'
           )
         })
       })
@@ -438,7 +434,7 @@ export function itBehavesLikeBaseBridgeTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/bridge/ConnextBridger.test.ts
+++ b/packages/tasks/test/bridge/ConnextBridger.test.ts
@@ -91,7 +91,7 @@ describe('ConnextBridger', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(task.setDefaultRelayerFee(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setDefaultRelayerFee(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -127,7 +127,7 @@ describe('ConnextBridger', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(task.setCustomRelayerFee(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setCustomRelayerFee(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -238,7 +238,7 @@ describe('ConnextBridger', () => {
                   context('when the relayer fee is too high', () => {
                     it('reverts', async () => {
                       await expect(task.call(token.address, amountIn, 0, relayerFee)).to.be.revertedWith(
-                        'TASK_FEE_TOO_HIGH'
+                        'TaskFeeTooHigh'
                       )
                     })
                   })
@@ -247,7 +247,7 @@ describe('ConnextBridger', () => {
                 context('when the slippage is above the limit', () => {
                   it('reverts', async () => {
                     await expect(task.call(token.address, amountIn, slippage, 0)).to.be.revertedWith(
-                      'TASK_SLIPPAGE_TOO_HIGH'
+                      'TaskSlippageTooHigh'
                     )
                   })
                 })
@@ -266,7 +266,7 @@ describe('ConnextBridger', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(token.address, amountIn, slippage, relayerFee)).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskTokenThresholdNotMet'
                   )
                 })
               })
@@ -281,7 +281,7 @@ describe('ConnextBridger', () => {
 
               it('reverts', async () => {
                 await expect(task.call(token.address, amountIn, slippage, relayerFee)).to.be.revertedWith(
-                  'TASK_TOKEN_NOT_ALLOWED'
+                  'TaskTokenNotAllowed'
                 )
               })
             })
@@ -290,7 +290,7 @@ describe('ConnextBridger', () => {
           context('when the destination chain was not set', () => {
             it('reverts', async () => {
               await expect(task.call(token.address, amountIn, slippage, relayerFee)).to.be.revertedWith(
-                'TASK_DESTINATION_CHAIN_NOT_SET'
+                'TaskDestinationChainNotSet'
               )
             })
           })
@@ -300,7 +300,7 @@ describe('ConnextBridger', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount, 0, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount, 0, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -309,14 +309,14 @@ describe('ConnextBridger', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/bridge/ConnextBridger.test.ts
+++ b/packages/tasks/test/bridge/ConnextBridger.test.ts
@@ -238,7 +238,7 @@ describe('ConnextBridger', () => {
                   context('when the relayer fee is too high', () => {
                     it('reverts', async () => {
                       await expect(task.call(token.address, amountIn, 0, relayerFee)).to.be.revertedWith(
-                        'TaskFeeTooHigh'
+                        'TaskFeePctAboveMax'
                       )
                     })
                   })

--- a/packages/tasks/test/bridge/ConnextBridger.test.ts
+++ b/packages/tasks/test/bridge/ConnextBridger.test.ts
@@ -247,7 +247,7 @@ describe('ConnextBridger', () => {
                 context('when the slippage is above the limit', () => {
                   it('reverts', async () => {
                     await expect(task.call(token.address, amountIn, slippage, 0)).to.be.revertedWith(
-                      'TaskSlippageTooHigh'
+                      'TaskSlippageAboveMax'
                     )
                   })
                 })

--- a/packages/tasks/test/bridge/HopBridger.test.ts
+++ b/packages/tasks/test/bridge/HopBridger.test.ts
@@ -94,7 +94,7 @@ describe('HopBridger', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -127,14 +127,14 @@ describe('HopBridger', () => {
         const deadline = 0
 
         it('reverts', async () => {
-          await expect(task.setMaxDeadline(deadline)).to.be.revertedWith('TASK_MAX_DEADLINE_ZERO')
+          await expect(task.setMaxDeadline(deadline)).to.be.revertedWith('TaskMaxDeadlineZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setMaxDeadline(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setMaxDeadline(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -164,7 +164,7 @@ describe('HopBridger', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(task.setDefaultMaxFeePct(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setDefaultMaxFeePct(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -200,7 +200,7 @@ describe('HopBridger', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(task.setCustomMaxFeePct(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setCustomMaxFeePct(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -293,16 +293,14 @@ describe('HopBridger', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.setTokenHopEntrypoint(token, ZERO_ADDRESS)).to.be.revertedWith('TASK_HOP_TOKEN_ZERO')
+          await expect(task.setTokenHopEntrypoint(token, ZERO_ADDRESS)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTokenHopEntrypoint(ZERO_ADDRESS, ZERO_ADDRESS)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(task.setTokenHopEntrypoint(ZERO_ADDRESS, ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -419,7 +417,7 @@ describe('HopBridger', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(token.address, amountIn, slippage, fee)).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskTokenThresholdNotMet'
                   )
                 })
               })
@@ -434,7 +432,7 @@ describe('HopBridger', () => {
 
               it('reverts', async () => {
                 await expect(task.call(token.address, amountIn, slippage, fee)).to.be.revertedWith(
-                  'TASK_TOKEN_NOT_ALLOWED'
+                  'TaskTokenNotAllowed'
                 )
               })
             })
@@ -443,7 +441,7 @@ describe('HopBridger', () => {
           context('when the destination chain was not set', () => {
             it('reverts', async () => {
               await expect(task.call(token.address, amountIn, slippage, fee)).to.be.revertedWith(
-                'TASK_DESTINATION_CHAIN_NOT_SET'
+                'TaskDestinationChainNotSet'
               )
             })
           })
@@ -453,7 +451,7 @@ describe('HopBridger', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount, 0, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount, 0, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -462,14 +460,14 @@ describe('HopBridger', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/bridge/WormholeBridger.test.ts
+++ b/packages/tasks/test/bridge/WormholeBridger.test.ts
@@ -158,9 +158,7 @@ describe('WormholeBridger', () => {
 
                 context('when the slippage is above the limit', () => {
                   it('reverts', async () => {
-                    await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith(
-                      'TASK_SLIPPAGE_TOO_HIGH'
-                    )
+                    await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
                   })
                 })
               })
@@ -178,7 +176,7 @@ describe('WormholeBridger', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskTokenThresholdNotMet'
                   )
                 })
               })
@@ -192,7 +190,7 @@ describe('WormholeBridger', () => {
               })
 
               it('reverts', async () => {
-                await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+                await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith('TaskTokenNotAllowed')
               })
             })
           })
@@ -200,7 +198,7 @@ describe('WormholeBridger', () => {
           context('when the destination chain was not set', () => {
             it('reverts', async () => {
               await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith(
-                'TASK_DESTINATION_CHAIN_NOT_SET'
+                'TaskDestinationChainNotSet'
               )
             })
           })
@@ -210,7 +208,7 @@ describe('WormholeBridger', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -219,14 +217,14 @@ describe('WormholeBridger', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/bridge/WormholeBridger.test.ts
+++ b/packages/tasks/test/bridge/WormholeBridger.test.ts
@@ -158,7 +158,9 @@ describe('WormholeBridger', () => {
 
                 context('when the slippage is above the limit', () => {
                   it('reverts', async () => {
-                    await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
+                    await expect(task.call(token.address, amountIn, slippage)).to.be.revertedWith(
+                      'TaskSlippageAboveMax'
+                    )
                   })
                 })
               })

--- a/packages/tasks/test/liquidity/convex/BaseConvexTask.behavior.ts
+++ b/packages/tasks/test/liquidity/convex/BaseConvexTask.behavior.ts
@@ -43,14 +43,14 @@ export function itBehavesLikeBaseConvexTask(executionType: string): void {
         const connector = ZERO_ADDRESS
 
         it('reverts', async function () {
-          await expect(this.task.setConnector(connector)).to.be.revertedWith('TASK_CONNECTOR_ZERO')
+          await expect(this.task.setConnector(connector)).to.be.revertedWith('TaskConnectorZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/convex/ConvexClaimer.test.ts
+++ b/packages/tasks/test/liquidity/convex/ConvexClaimer.test.ts
@@ -99,7 +99,7 @@ describe('ConvexClaimer', () => {
           const amount = 1
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_AMOUNT_NOT_ZERO')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskAmountNotZero')
           })
         })
       })
@@ -108,14 +108,14 @@ describe('ConvexClaimer', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/convex/ConvexExiter.test.ts
+++ b/packages/tasks/test/liquidity/convex/ConvexExiter.test.ts
@@ -149,7 +149,7 @@ describe('ConvexExiter', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+              await expect(task.call(token.address, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
             })
           })
         })
@@ -158,7 +158,7 @@ describe('ConvexExiter', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -167,14 +167,14 @@ describe('ConvexExiter', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/convex/ConvexJoiner.test.ts
+++ b/packages/tasks/test/liquidity/convex/ConvexJoiner.test.ts
@@ -149,7 +149,7 @@ describe('ConvexJoiner', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+              await expect(task.call(token.address, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
             })
           })
         })
@@ -158,7 +158,7 @@ describe('ConvexJoiner', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -167,14 +167,14 @@ describe('ConvexJoiner', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/curve/BaseCurveTask.behavior.ts
+++ b/packages/tasks/test/liquidity/curve/BaseCurveTask.behavior.ts
@@ -43,14 +43,14 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
         const connector = ZERO_ADDRESS
 
         it('reverts', async function () {
-          await expect(this.task.setConnector(connector)).to.be.revertedWith('TASK_CONNECTOR_ZERO')
+          await expect(this.task.setConnector(connector)).to.be.revertedWith('TaskConnectorZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -86,7 +86,7 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultTokenOut(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultTokenOut(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -124,7 +124,7 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
         await expect(this.task.setCustomTokenOut(token.address, tokenOut.address)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -160,14 +160,14 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
         const slippage = fp(1).add(1)
 
         it('reverts', async function () {
-          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TASK_SLIPPAGE_ABOVE_ONE')
+          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TaskSlippageAboveOne')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -209,7 +209,7 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
 
         it('reverts', async function () {
           await expect(this.task.setCustomMaxSlippage(token.address, slippage)).to.be.revertedWith(
-            'TASK_SLIPPAGE_ABOVE_ONE'
+            'TaskSlippageAboveOne'
           )
         })
       })
@@ -217,7 +217,7 @@ export function itBehavesLikeBaseCurveTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/curve/Curve2CrvExiter.test.ts
+++ b/packages/tasks/test/liquidity/curve/Curve2CrvExiter.test.ts
@@ -170,7 +170,7 @@ describe('Curve2CrvExiter', () => {
                 const slippage = fp(0.01)
 
                 it('reverts', async () => {
-                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
+                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageAboveMax')
                 })
               })
             })

--- a/packages/tasks/test/liquidity/curve/Curve2CrvExiter.test.ts
+++ b/packages/tasks/test/liquidity/curve/Curve2CrvExiter.test.ts
@@ -170,7 +170,7 @@ describe('Curve2CrvExiter', () => {
                 const slippage = fp(0.01)
 
                 it('reverts', async () => {
-                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TASK_SLIPPAGE_TOO_HIGH')
+                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
                 })
               })
             })
@@ -185,14 +185,14 @@ describe('Curve2CrvExiter', () => {
               })
 
               it('reverts', async () => {
-                await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+                await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskTokenThresholdNotMet')
               })
             })
           })
 
           context('when there is no token out set', () => {
             it('reverts', async () => {
-              await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_TOKEN_OUT_NOT_SET')
+              await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskTokenOutNotSet')
             })
           })
         })
@@ -201,7 +201,7 @@ describe('Curve2CrvExiter', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -210,14 +210,14 @@ describe('Curve2CrvExiter', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/curve/Curve2CrvJoiner.test.ts
+++ b/packages/tasks/test/liquidity/curve/Curve2CrvJoiner.test.ts
@@ -170,7 +170,7 @@ describe('Curve2CrvJoiner', () => {
                 const slippage = fp(0.01)
 
                 it('reverts', async () => {
-                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TASK_SLIPPAGE_TOO_HIGH')
+                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
                 })
               })
             })
@@ -185,14 +185,14 @@ describe('Curve2CrvJoiner', () => {
               })
 
               it('reverts', async () => {
-                await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+                await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskTokenThresholdNotMet')
               })
             })
           })
 
           context('when there is no token out set', () => {
             it('reverts', async () => {
-              await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_TOKEN_OUT_NOT_SET')
+              await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskTokenOutNotSet')
             })
           })
         })
@@ -201,7 +201,7 @@ describe('Curve2CrvJoiner', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token.address, amount, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -210,14 +210,14 @@ describe('Curve2CrvJoiner', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(token, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/liquidity/curve/Curve2CrvJoiner.test.ts
+++ b/packages/tasks/test/liquidity/curve/Curve2CrvJoiner.test.ts
@@ -170,7 +170,7 @@ describe('Curve2CrvJoiner', () => {
                 const slippage = fp(0.01)
 
                 it('reverts', async () => {
-                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageTooHigh')
+                  await expect(task.call(token.address, amount, slippage)).to.be.revertedWith('TaskSlippageAboveMax')
                 })
               })
             })

--- a/packages/tasks/test/primitives/Collector.test.ts
+++ b/packages/tasks/test/primitives/Collector.test.ts
@@ -78,9 +78,7 @@ describe('Collector', () => {
           const previous = '0x0000000000000000000000000000000000000000000000000000000000000002'
 
           it('reverts', async () => {
-            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith(
-              'TASK_PREVIOUS_CONNECTOR_NOT_ZERO'
-            )
+            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith('TaskPreviousConnectorNotZero')
           })
         })
       })
@@ -95,9 +93,7 @@ describe('Collector', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -132,14 +128,14 @@ describe('Collector', () => {
         const newSource = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.setTokensSource(newSource)).to.be.revertedWith('TASK_TOKENS_SOURCE_ZERO')
+          await expect(task.setTokensSource(newSource)).to.be.revertedWith('TaskTokensSourceZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -238,21 +234,21 @@ describe('Collector', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
           })
         })
       })
 
       context('when the given token is not allowed', () => {
         it('reverts', async () => {
-          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TaskTokenNotAllowed')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(token.address, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(token.address, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/primitives/Depositor.test.ts
+++ b/packages/tasks/test/primitives/Depositor.test.ts
@@ -81,14 +81,14 @@ describe('Depositor', () => {
 
       context('when the new address is another', async () => {
         it('reverts', async () => {
-          await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('TASK_DEPOSITOR_BAD_TOKENS_SOURCE')
+          await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('TaskDepositorBadTokensSource')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTokensSource(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -161,21 +161,21 @@ describe('Depositor', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
           })
         })
       })
 
       context('when the given token is not allowed', () => {
         it('reverts', async () => {
-          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TaskTokenNotAllowed')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(token.address, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(token.address, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/primitives/Unwrapper.test.ts
+++ b/packages/tasks/test/primitives/Unwrapper.test.ts
@@ -123,7 +123,7 @@ describe('Unwrapper', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(token, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+              await expect(task.call(token, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
             })
           })
         })
@@ -132,7 +132,7 @@ describe('Unwrapper', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -141,14 +141,14 @@ describe('Unwrapper', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_NOT_WRAPPED')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenNotWrapped')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/primitives/Withdrawer.test.ts
+++ b/packages/tasks/test/primitives/Withdrawer.test.ts
@@ -78,7 +78,7 @@ describe('Withdrawer', () => {
           const next = '0x0000000000000000000000000000000000000000000000000000000000000002'
 
           it('reverts', async () => {
-            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith('TASK_NEXT_CONNECTOR_NOT_ZERO')
+            await expect(task.setBalanceConnectors(previous, next)).to.be.revertedWith('TaskNextConnectorNotZero')
           })
         })
       })
@@ -93,9 +93,7 @@ describe('Withdrawer', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
-        )
+        await expect(task.setBalanceConnectors(ZERO_BYTES32, ZERO_BYTES32)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -135,7 +133,7 @@ describe('Withdrawer', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TASK_RECIPIENT_SMART_VAULT')
+            await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TaskRecipientSmartVault')
           })
         })
       })
@@ -144,14 +142,14 @@ describe('Withdrawer', () => {
         const newRecipient = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TASK_RECIPIENT_ZERO')
+          await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TaskRecipientZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setRecipient(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setRecipient(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -240,21 +238,21 @@ describe('Withdrawer', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
           })
         })
       })
 
       context('when the given token is not allowed', () => {
         it('reverts', async () => {
-          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TaskTokenNotAllowed')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(token.address, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(token.address, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/primitives/Withdrawer.test.ts
+++ b/packages/tasks/test/primitives/Withdrawer.test.ts
@@ -16,6 +16,8 @@ import { ethers } from 'hardhat'
 
 import { buildEmptyTaskConfig, deployEnvironment, Mimic } from '../../src/setup'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('Withdrawer', () => {
   let task: Contract
   let smartVault: Contract, authorizer: Contract, mimic: Mimic, owner: SignerWithAddress, recipient: SignerWithAddress
@@ -133,7 +135,7 @@ describe('Withdrawer', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TaskRecipientSmartVault')
+            await expect(task.setRecipient(newRecipient)).to.be.revertedWith('TaskRecipientEqualsSmartVault')
           })
         })
       })

--- a/packages/tasks/test/primitives/Wrapper.test.ts
+++ b/packages/tasks/test/primitives/Wrapper.test.ts
@@ -118,7 +118,7 @@ describe('Wrapper', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(token, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+              await expect(task.call(token, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
             })
           })
         })
@@ -127,7 +127,7 @@ describe('Wrapper', () => {
           const amount = 0
 
           it('reverts', async () => {
-            await expect(task.call(token, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(token, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -136,14 +136,14 @@ describe('Wrapper', () => {
         const token = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(token, 0)).to.be.revertedWith('TASK_TOKEN_NOT_NATIVE')
+          await expect(task.call(token, 0)).to.be.revertedWith('TaskTokenNotNative')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/relayer/BaseRelayerFundTask.behavior.ts
+++ b/packages/tasks/test/relayer/BaseRelayerFundTask.behavior.ts
@@ -35,14 +35,14 @@ export function itBehavesLikeBaseRelayerFundTask(executionType: string): void {
 
       context('when the relayer is zero', () => {
         it('reverts', async function () {
-          await expect(this.task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('TASK_FUNDER_RELAYER_ZERO')
+          await expect(this.task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('TaskRelayerZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setRelayer(this.relayer.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setRelayer(this.relayer.address)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/relayer/CollectorRelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/CollectorRelayerFunder.test.ts
@@ -17,6 +17,8 @@ import { Contract } from 'ethers'
 import { buildEmptyTaskConfig, deployEnvironment } from '../../src/setup'
 import { itBehavesLikeBaseRelayerFundTask } from './BaseRelayerFundTask.behavior'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('CollectorRelayerFunder', () => {
   let task: Contract, relayer: Contract
   let smartVault: Contract, authorizer: Contract, priceOracle: Contract
@@ -54,7 +56,7 @@ describe('CollectorRelayerFunder', () => {
           tokensSource: tokensSource.address,
           taskConfig: buildEmptyTaskConfig(owner, smartVault),
         })
-      ).to.be.revertedWith('COLLECTOR_INITIALIZER_DISABLED')
+      ).to.be.revertedWith('TaskInitializerDisabled')
     })
 
     it('has a relayer reference', async () => {
@@ -187,7 +189,7 @@ describe('CollectorRelayerFunder', () => {
             const bigAmount = amount.add(diff.add(1))
 
             it('reverts', async () => {
-              await expect(task.call(token.address, bigAmount)).to.be.revertedWith('TASK_AMOUNT_ABOVE_THRESHOLD')
+              await expect(task.call(token.address, bigAmount)).to.be.revertedWith('TaskAmountAboveMaxThreshold')
             })
           })
         })
@@ -210,21 +212,21 @@ describe('CollectorRelayerFunder', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskDepositedAboveMinThreshold')
           })
         })
       })
 
       context('when the given token is not allowed', () => {
         it('reverts', async () => {
-          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+          await expect(task.call(NATIVE_TOKEN_ADDRESS, 0)).to.be.revertedWith('TaskTokenNotAllowed')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(token.address, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(token.address, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/relayer/CollectorRelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/CollectorRelayerFunder.test.ts
@@ -189,7 +189,7 @@ describe('CollectorRelayerFunder', () => {
             const bigAmount = amount.add(diff.add(1))
 
             it('reverts', async () => {
-              await expect(task.call(token.address, bigAmount)).to.be.revertedWith('TaskAmountAboveMaxThreshold')
+              await expect(task.call(token.address, bigAmount)).to.be.revertedWith('TaskDepositAboveMaxThreshold')
             })
           })
         })
@@ -212,7 +212,7 @@ describe('CollectorRelayerFunder', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskDepositedAboveMinThreshold')
+            await expect(task.call(token.address, amount)).to.be.revertedWith('TaskDepositAboveMinThreshold')
           })
         })
       })

--- a/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
@@ -251,7 +251,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                     it('reverts', async () => {
                       await expect(task.call(tokenIn.address, amount, slippage, data)).to.be.revertedWith(
-                        'TaskAmountAboveMaxThreshold'
+                        'TaskDepositAboveMaxThreshold'
                       )
                     })
                   })
@@ -282,7 +282,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith(
-                    'TaskDepositedAboveMinThreshold'
+                    'TaskDepositAboveMinThreshold'
                   )
                 })
               })

--- a/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
@@ -18,6 +18,8 @@ import { Contract } from 'ethers'
 import { buildEmptyTaskConfig, deployEnvironment } from '../../src/setup'
 import { itBehavesLikeBaseRelayerFundTask } from './BaseRelayerFundTask.behavior'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('OneInchV5RelayerFunder', () => {
   let task: Contract, relayer: Contract
   let smartVault: Contract, authorizer: Contract, priceOracle: Contract, connector: Contract, owner: SignerWithAddress
@@ -73,7 +75,7 @@ describe('OneInchV5RelayerFunder', () => {
             taskConfig: buildEmptyTaskConfig(owner, smartVault),
           },
         })
-      ).to.be.revertedWith('SWAPPER_INITIALIZER_DISABLED')
+      ).to.be.revertedWith('TaskInitializerDisabled')
     })
 
     it('has a relayer reference', async () => {
@@ -249,7 +251,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                     it('reverts', async () => {
                       await expect(task.call(tokenIn.address, amount, slippage, data)).to.be.revertedWith(
-                        'TASK_AMOUNT_ABOVE_THRESHOLD'
+                        'TaskAmountAboveMaxThreshold'
                       )
                     })
                   })
@@ -260,7 +262,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                   it('reverts', async () => {
                     await expect(task.call(tokenIn.address, amountIn, slippage, '0x')).to.be.revertedWith(
-                      'TASK_SLIPPAGE_TOO_HIGH'
+                      'TaskSlippageTooHigh'
                     )
                   })
                 })
@@ -280,7 +282,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskDepositedAboveMinThreshold'
                   )
                 })
               })
@@ -303,7 +305,7 @@ describe('OneInchV5RelayerFunder', () => {
               })
 
               it('reverts', async () => {
-                await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TASK_TOKEN_OUT_NOT_SET')
+                await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TaskTokenOutNotSet')
               })
             })
           })
@@ -316,7 +318,7 @@ describe('OneInchV5RelayerFunder', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(tokenIn.address, 0, 0, '0x')).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+              await expect(task.call(tokenIn.address, 0, 0, '0x')).to.be.revertedWith('TaskTokenNotAllowed')
             })
           })
         })
@@ -339,7 +341,7 @@ describe('OneInchV5RelayerFunder', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -355,7 +357,7 @@ describe('OneInchV5RelayerFunder', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0, '0x')).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0, '0x')).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/OneInchV5RelayerFunder.test.ts
@@ -262,7 +262,7 @@ describe('OneInchV5RelayerFunder', () => {
 
                   it('reverts', async () => {
                     await expect(task.call(tokenIn.address, amountIn, slippage, '0x')).to.be.revertedWith(
-                      'TaskSlippageTooHigh'
+                      'TaskSlippageAboveMax'
                     )
                   })
                 })

--- a/packages/tasks/test/relayer/RelayerDepositor.test.ts
+++ b/packages/tasks/test/relayer/RelayerDepositor.test.ts
@@ -65,14 +65,14 @@ describe('RelayerDepositor', () => {
 
       context('when the relayer is zero', () => {
         it('reverts', async () => {
-          await expect(task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('TASK_RELAYER_DEPOSITOR_ZERO')
+          await expect(task.setRelayer(ZERO_ADDRESS)).to.be.revertedWith('TaskRelayerZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setRelayer(relayer.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setRelayer(relayer.address)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -142,7 +142,7 @@ describe('RelayerDepositor', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(token, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+            await expect(task.call(token, amount)).to.be.revertedWith('TaskTokenThresholdNotMet')
           })
         })
       })
@@ -151,14 +151,14 @@ describe('RelayerDepositor', () => {
         const amount = 0
 
         it('reverts', async () => {
-          await expect(task.call(token, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+          await expect(task.call(token, amount)).to.be.revertedWith('TaskAmountZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(token, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(token, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/relayer/UnwrapperRelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/UnwrapperRelayerFunder.test.ts
@@ -158,7 +158,7 @@ describe('UnwrapperRelayerFunder', () => {
               const bigAmount = amount.add(diff.add(1))
 
               it('reverts', async () => {
-                await expect(task.call(tokenAddr, bigAmount)).to.be.revertedWith('TaskAmountAboveMaxThreshold')
+                await expect(task.call(tokenAddr, bigAmount)).to.be.revertedWith('TaskDepositAboveMaxThreshold')
               })
             })
           })
@@ -180,7 +180,7 @@ describe('UnwrapperRelayerFunder', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TaskDepositedAboveMinThreshold')
+              await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TaskDepositAboveMinThreshold')
             })
           })
         })

--- a/packages/tasks/test/relayer/UnwrapperRelayerFunder.test.ts
+++ b/packages/tasks/test/relayer/UnwrapperRelayerFunder.test.ts
@@ -18,6 +18,8 @@ import { Contract } from 'ethers'
 import { buildEmptyTaskConfig, deployEnvironment, Mimic } from '../../src/setup'
 import { itBehavesLikeBaseRelayerFundTask } from './BaseRelayerFundTask.behavior'
 
+/* eslint-disable no-secrets/no-secrets */
+
 describe('UnwrapperRelayerFunder', () => {
   let task: Contract, relayer: Contract
   let smartVault: Contract, authorizer: Contract, priceOracle: Contract, mimic: Mimic, owner: SignerWithAddress
@@ -52,7 +54,7 @@ describe('UnwrapperRelayerFunder', () => {
         task.initialize({
           taskConfig: buildEmptyTaskConfig(owner, smartVault),
         })
-      ).to.be.revertedWith('UNWRAPPER_INITIALIZER_DISABLED')
+      ).to.be.revertedWith('TaskInitializerDisabled')
     })
 
     it('has a relayer reference', async () => {
@@ -156,7 +158,7 @@ describe('UnwrapperRelayerFunder', () => {
               const bigAmount = amount.add(diff.add(1))
 
               it('reverts', async () => {
-                await expect(task.call(tokenAddr, bigAmount)).to.be.revertedWith('TASK_AMOUNT_ABOVE_THRESHOLD')
+                await expect(task.call(tokenAddr, bigAmount)).to.be.revertedWith('TaskAmountAboveMaxThreshold')
               })
             })
           })
@@ -178,7 +180,7 @@ describe('UnwrapperRelayerFunder', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TASK_TOKEN_THRESHOLD_NOT_MET')
+              await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TaskDepositedAboveMinThreshold')
             })
           })
         })
@@ -194,7 +196,7 @@ describe('UnwrapperRelayerFunder', () => {
           })
 
           it('reverts', async () => {
-            await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(tokenAddr, amount)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -221,14 +223,14 @@ describe('UnwrapperRelayerFunder', () => {
         })
 
         it('reverts', async () => {
-          await expect(task.call(token.address, 0)).to.be.revertedWith('TASK_TOKEN_NOT_WRAPPED')
+          await expect(task.call(token.address, 0)).to.be.revertedWith('TaskTokenNotWrapped')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/swap/BaseSwapTask.behavior.ts
+++ b/packages/tasks/test/swap/BaseSwapTask.behavior.ts
@@ -40,7 +40,7 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setConnector(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -76,7 +76,7 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultTokenOut(ZERO_ADDRESS)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultTokenOut(ZERO_ADDRESS)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -114,7 +114,7 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
         await expect(this.task.setCustomTokenOut(token.address, tokenOut.address)).to.be.revertedWith(
-          'AUTH_SENDER_NOT_ALLOWED'
+          'AuthSenderNotAllowed'
         )
       })
     })
@@ -150,14 +150,14 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
         const slippage = fp(1).add(1)
 
         it('reverts', async function () {
-          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TASK_SLIPPAGE_ABOVE_ONE')
+          await expect(this.task.setDefaultMaxSlippage(slippage)).to.be.revertedWith('TaskSlippageAboveOne')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setDefaultMaxSlippage(1)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -199,7 +199,7 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
 
         it('reverts', async function () {
           await expect(this.task.setCustomMaxSlippage(token.address, slippage)).to.be.revertedWith(
-            'TASK_SLIPPAGE_ABOVE_ONE'
+            'TaskSlippageAboveOne'
           )
         })
       })
@@ -207,7 +207,7 @@ export function itBehavesLikeBaseSwapTask(executionType: string): void {
 
     context('when the sender is not authorized', () => {
       it('reverts', async function () {
-        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(this.task.setCustomMaxSlippage(ZERO_ADDRESS, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/swap/HopL2Swapper.test.ts
+++ b/packages/tasks/test/swap/HopL2Swapper.test.ts
@@ -299,7 +299,7 @@ describe('HopL2Swapper', () => {
 
                     it('reverts', async () => {
                       await expect(task.call(tokenIn.address, amountIn, slippage)).to.be.revertedWith(
-                        'TaskSlippageTooHigh'
+                        'TaskSlippageAboveMax'
                       )
                     })
                   })

--- a/packages/tasks/test/swap/HopL2Swapper.test.ts
+++ b/packages/tasks/test/swap/HopL2Swapper.test.ts
@@ -151,14 +151,14 @@ describe('HopL2Swapper', () => {
         const hToken = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.setTokenAmm(hToken, amm.address)).to.be.revertedWith('TASK_HOP_TOKEN_ZERO')
+          await expect(task.setTokenAmm(hToken, amm.address)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setTokenAmm(hToken.address, amm.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setTokenAmm(hToken.address, amm.address)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -299,7 +299,7 @@ describe('HopL2Swapper', () => {
 
                     it('reverts', async () => {
                       await expect(task.call(tokenIn.address, amountIn, slippage)).to.be.revertedWith(
-                        'TASK_SLIPPAGE_TOO_HIGH'
+                        'TaskSlippageTooHigh'
                       )
                     })
                   })
@@ -313,23 +313,21 @@ describe('HopL2Swapper', () => {
                   })
 
                   it('reverts', async () => {
-                    await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith(
-                      'TASK_TOKEN_THRESHOLD_NOT_MET'
-                    )
+                    await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TaskTokenThresholdNotMet')
                   })
                 })
               })
 
               context('when the given token does not have an AMM set', () => {
                 it('reverts', async () => {
-                  await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TASK_MISSING_HOP_TOKEN_AMM')
+                  await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TaskMissingHopTokenAmm')
                 })
               })
             })
 
             context('when the token out is not set', () => {
               it('reverts', async () => {
-                await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TASK_TOKEN_OUT_NOT_SET')
+                await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TaskTokenOutNotSet')
               })
             })
           })
@@ -342,7 +340,7 @@ describe('HopL2Swapper', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(tokenIn.address, 0, 0)).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+              await expect(task.call(tokenIn.address, 0, 0)).to.be.revertedWith('TaskTokenNotAllowed')
             })
           })
         })
@@ -351,7 +349,7 @@ describe('HopL2Swapper', () => {
           const amountIn = 0
 
           it('reverts', async () => {
-            await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(tokenIn.address, amountIn, 0)).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -360,14 +358,14 @@ describe('HopL2Swapper', () => {
         const tokenIn = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(tokenIn, 0, 0)).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(tokenIn, 0, 0)).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/swap/OneInchV5Swapper.test.ts
+++ b/packages/tasks/test/swap/OneInchV5Swapper.test.ts
@@ -192,7 +192,7 @@ describe('OneInchV5Swapper', () => {
 
                   it('reverts', async () => {
                     await expect(task.call(tokenIn.address, amountIn, slippage, '0x')).to.be.revertedWith(
-                      'TASK_SLIPPAGE_TOO_HIGH'
+                      'TaskSlippageTooHigh'
                     )
                   })
                 })
@@ -207,7 +207,7 @@ describe('OneInchV5Swapper', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskTokenThresholdNotMet'
                   )
                 })
               })
@@ -215,7 +215,7 @@ describe('OneInchV5Swapper', () => {
 
             context('when the token out is not set', () => {
               it('reverts', async () => {
-                await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TASK_TOKEN_OUT_NOT_SET')
+                await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TaskTokenOutNotSet')
               })
             })
           })
@@ -228,7 +228,7 @@ describe('OneInchV5Swapper', () => {
             })
 
             it('reverts', async () => {
-              await expect(task.call(tokenIn.address, 0, 0, '0x')).to.be.revertedWith('TASK_TOKEN_NOT_ALLOWED')
+              await expect(task.call(tokenIn.address, 0, 0, '0x')).to.be.revertedWith('TaskTokenNotAllowed')
             })
           })
         })
@@ -237,7 +237,7 @@ describe('OneInchV5Swapper', () => {
           const amountIn = 0
 
           it('reverts', async () => {
-            await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TASK_AMOUNT_ZERO')
+            await expect(task.call(tokenIn.address, amountIn, 0, '0x')).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -246,14 +246,14 @@ describe('OneInchV5Swapper', () => {
         const tokenIn = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(tokenIn, 0, 0, '0x')).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(tokenIn, 0, 0, '0x')).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 0, '0x')).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 0, '0x')).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/swap/OneInchV5Swapper.test.ts
+++ b/packages/tasks/test/swap/OneInchV5Swapper.test.ts
@@ -192,7 +192,7 @@ describe('OneInchV5Swapper', () => {
 
                   it('reverts', async () => {
                     await expect(task.call(tokenIn.address, amountIn, slippage, '0x')).to.be.revertedWith(
-                      'TaskSlippageTooHigh'
+                      'TaskSlippageAboveMax'
                     )
                   })
                 })

--- a/packages/tasks/test/swap/ParaswapV5Swapper.test.ts
+++ b/packages/tasks/test/swap/ParaswapV5Swapper.test.ts
@@ -94,7 +94,7 @@ describe('ParaswapV5Swapper', () => {
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.setQuoteSigner(quoteSigner.address)).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.setQuoteSigner(quoteSigner.address)).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })
@@ -322,7 +322,7 @@ describe('ParaswapV5Swapper', () => {
                             data,
                             signature
                           )
-                        ).to.be.revertedWith('TASK_QUOTE_SIGNER_DEADLINE')
+                        ).to.be.revertedWith('TaskQuoteSignerDeadline')
                       })
                     })
                   })
@@ -333,7 +333,7 @@ describe('ParaswapV5Swapper', () => {
 
                       await expect(
                         task.call(tokenIn.address, amountIn, minAmountOut, expectedAmountOut, 0, data, signature)
-                      ).to.be.revertedWith('TASK_QUOTE_SIGNER_DEADLINE')
+                      ).to.be.revertedWith('TaskQuoteSignerDeadline')
                     })
                   })
                 })
@@ -345,7 +345,7 @@ describe('ParaswapV5Swapper', () => {
                   it('reverts', async () => {
                     await expect(
                       task.call(tokenIn.address, amountIn, minAmountOut, expectedAmountOut, 0, '0x', '0x')
-                    ).to.be.revertedWith('TASK_SLIPPAGE_TOO_HIGH')
+                    ).to.be.revertedWith('TaskSlippageTooHigh')
                   })
                 })
               })
@@ -359,7 +359,7 @@ describe('ParaswapV5Swapper', () => {
 
                 it('reverts', async () => {
                   await expect(task.call(tokenIn.address, amountIn, 1, 1, 0, '0x', '0x')).to.be.revertedWith(
-                    'TASK_TOKEN_THRESHOLD_NOT_MET'
+                    'TaskTokenThresholdNotMet'
                   )
                 })
               })
@@ -368,7 +368,7 @@ describe('ParaswapV5Swapper', () => {
             context('when the token out is not set', () => {
               it('reverts', async () => {
                 await expect(task.call(tokenIn.address, amountIn, 1, 1, 0, '0x', '0x')).to.be.revertedWith(
-                  'TASK_TOKEN_OUT_NOT_SET'
+                  'TaskTokenOutNotSet'
                 )
               })
             })
@@ -383,7 +383,7 @@ describe('ParaswapV5Swapper', () => {
 
             it('reverts', async () => {
               await expect(task.call(tokenIn.address, amountIn, 1, 1, 0, '0x', '0x')).to.be.revertedWith(
-                'TASK_TOKEN_NOT_ALLOWED'
+                'TaskTokenNotAllowed'
               )
             })
           })
@@ -393,9 +393,7 @@ describe('ParaswapV5Swapper', () => {
           const amountIn = 0
 
           it('reverts', async () => {
-            await expect(task.call(tokenIn.address, amountIn, 1, 1, 0, '0x', '0x')).to.be.revertedWith(
-              'TASK_AMOUNT_ZERO'
-            )
+            await expect(task.call(tokenIn.address, amountIn, 1, 1, 0, '0x', '0x')).to.be.revertedWith('TaskAmountZero')
           })
         })
       })
@@ -404,14 +402,14 @@ describe('ParaswapV5Swapper', () => {
         const tokenIn = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await expect(task.call(tokenIn, 0, 1, 1, 0, '0x', '0x')).to.be.revertedWith('TASK_TOKEN_ZERO')
+          await expect(task.call(tokenIn, 0, 1, 1, 0, '0x', '0x')).to.be.revertedWith('TaskTokenZero')
         })
       })
     })
 
     context('when the sender is not authorized', () => {
       it('reverts', async () => {
-        await expect(task.call(ZERO_ADDRESS, 0, 1, 1, 0, '0x', '0x')).to.be.revertedWith('AUTH_SENDER_NOT_ALLOWED')
+        await expect(task.call(ZERO_ADDRESS, 0, 1, 1, 0, '0x', '0x')).to.be.revertedWith('AuthSenderNotAllowed')
       })
     })
   })

--- a/packages/tasks/test/swap/ParaswapV5Swapper.test.ts
+++ b/packages/tasks/test/swap/ParaswapV5Swapper.test.ts
@@ -322,7 +322,7 @@ describe('ParaswapV5Swapper', () => {
                             data,
                             signature
                           )
-                        ).to.be.revertedWith('TaskQuoteSignerDeadline')
+                        ).to.be.revertedWith('TaskQuoteSignerPastDeadline')
                       })
                     })
                   })
@@ -333,7 +333,7 @@ describe('ParaswapV5Swapper', () => {
 
                       await expect(
                         task.call(tokenIn.address, amountIn, minAmountOut, expectedAmountOut, 0, data, signature)
-                      ).to.be.revertedWith('TaskQuoteSignerDeadline')
+                      ).to.be.revertedWith('TaskQuoteSignerPastDeadline')
                     })
                   })
                 })
@@ -345,7 +345,7 @@ describe('ParaswapV5Swapper', () => {
                   it('reverts', async () => {
                     await expect(
                       task.call(tokenIn.address, amountIn, minAmountOut, expectedAmountOut, 0, '0x', '0x')
-                    ).to.be.revertedWith('TaskSlippageTooHigh')
+                    ).to.be.revertedWith('TaskSlippageAboveMax')
                   })
                 })
               })


### PR DESCRIPTION
This PR replaces `require` strings with custom errors.
TODO: use `revertedWithCustomError` in tests (https://hardhat.org/hardhat-chai-matchers/docs/reference#.revertedwithcustomerror)