### PR TITLE
Tasks: Implement new time lock modes

### DIFF
--- a/packages/authorizer/contracts/AuthorizedHelpers.sol
+++ b/packages/authorizer/contracts/AuthorizedHelpers.sol
@@ -84,6 +84,14 @@ contract AuthorizedHelpers {
         r[2] = p3;
     }
 
+    function authParams(uint256 p1, uint256 p2, uint256 p3, uint256 p4) internal pure returns (uint256[] memory r) {
+        r = new uint256[](4);
+        r[0] = p1;
+        r[1] = p2;
+        r[2] = p3;
+        r[3] = p4;
+    }
+
     function authParams(address p1, address p2, uint256 p3, uint256 p4) internal pure returns (uint256[] memory r) {
         r = new uint256[](4);
         r[0] = uint256(uint160(p1));

--- a/packages/authorizer/package.json
+++ b/packages/authorizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimic-fi/v3-authorizer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "GPL-3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -263,7 +263,7 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
     {
         (uint256 year, uint256 month, uint256 day) = allowedAt.timestampToDate();
         uint256 nextMonth = (month + monthsToIncrease) % 12;
-        uint256 nextYear = nextMonth > month ? year : (year + 1);
+        uint256 nextYear = year + ((month + monthsToIncrease) / 12);
         uint256 nextDay = _mode == Mode.OnLastMonthDay ? DateTime._getDaysInMonth(nextYear, nextMonth) : day;
         return _getAllowedDateFor(allowedAt, nextYear, nextMonth, nextDay);
     }

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -156,10 +156,12 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
 
             // Construct when would be the current allowed timestamp only considering the current month and year
             uint256 currentAllowedAt = _getCurrentAllowedDateForMonthlyRelativeFrequency(allowedAt, day);
+            if (block.timestamp < currentAllowedAt) revert TaskTimeLockActive(block.timestamp, currentAllowedAt);
 
-            // Since we already checked the current timestamp is not before the allowed timestamp set,
-            // we simply need to check we are within the allowed execution window
-            if (block.timestamp - currentAllowedAt > window) revert TaskTimeLockActive(block.timestamp, allowedAt);
+            // Otherwise, we simply need to check we are within the allowed execution window
+            uint256 finalCurrentAllowedAt = currentAllowedAt + window;
+            bool exceedsExecutionWindow = block.timestamp > finalCurrentAllowedAt;
+            if (exceedsExecutionWindow) revert TaskTimeLockActive(block.timestamp, finalCurrentAllowedAt);
 
             // Finally set the next allowed date to the corresponding number of months from the current date
             _nextAllowedAt = _getNextAllowedDateForMonthlyRelativeFrequency(currentAllowedAt, monthsToAdd);

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -260,7 +260,7 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
         returns (uint256)
     {
         (uint256 year, uint256 month, uint256 day) = allowedAt.timestampToDate();
-        uint256 nextMonth = month + (monthsToIncrease % 12);
+        uint256 nextMonth = (month + monthsToIncrease) % 12;
         uint256 nextYear = nextMonth > month ? year : (year + 1);
         uint256 nextDay = _mode == Mode.OnLastMonthDay ? DateTime._getDaysInMonth(nextYear, nextMonth) : day;
         return _getAllowedDateFor(allowedAt, nextYear, nextMonth, nextDay);

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -158,7 +158,7 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
             uint256 currentAllowedAt = _getCurrentAllowedDateForMonthlyRelativeFrequency(allowedAt, day);
 
             // Since we already checked the current timestamp is not before the allowed timestamp set,
-            // we simply need to check we are withing the allowed execution window
+            // we simply need to check we are within the allowed execution window
             if (block.timestamp - currentAllowedAt > window) revert TaskTimeLockActive(block.timestamp, allowedAt);
 
             // Finally set the next allowed date to the corresponding number of months from the current date

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -130,7 +130,7 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
             }
         } else {
             if (block.timestamp >= allowedAt && block.timestamp <= allowedAt + window) {
-                // Check the current timestamp has not passed the allowed at set
+                // Check the current timestamp has not passed the allowed date set
                 _nextAllowedAt = _getNextAllowedDate(allowedAt, frequency);
             } else {
                 // Check the current timestamp is not before the current allowed date
@@ -223,8 +223,9 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
      */
     function _getNextAllowedDate(uint256 allowedAt, uint256 monthsToIncrease) private view returns (uint256) {
         (uint256 year, uint256 month, uint256 day) = allowedAt.timestampToDate();
-        uint256 nextMonth = (month + monthsToIncrease) % 12;
-        uint256 nextYear = year + ((month + monthsToIncrease) / 12);
+        uint256 increasedMonth = month + monthsToIncrease;
+        uint256 nextMonth = increasedMonth % 12;
+        uint256 nextYear = year + (increasedMonth / 12);
         uint256 nextDay = _mode == Mode.OnLastMonthDay ? DateTime._getDaysInMonth(nextYear, nextMonth) : day;
         return _getAllowedDateFor(allowedAt, nextYear, nextMonth, nextDay);
     }

--- a/packages/tasks/contracts/base/TimeLockedTask.sol
+++ b/packages/tasks/contracts/base/TimeLockedTask.sol
@@ -14,32 +14,60 @@
 
 pragma solidity ^0.8.3;
 
+import '@quant-finance/solidity-datetime/contracts/DateTime.sol';
 import '@mimic-fi/v3-authorizer/contracts/Authorized.sol';
+
 import '../interfaces/base/ITimeLockedTask.sol';
 
 /**
  * @dev Time lock config for tasks. It allows limiting the frequency of a task.
  */
 abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
-    // Period in seconds that must pass after a task has been executed
-    uint256 public override timeLockDelay;
+    using DateTime for uint256;
 
-    // Future timestamp in which the task can be executed
-    uint256 public override timeLockExpiration;
+    uint256 private constant DAYS_28 = 60 * 60 * 24 * 28;
 
-    // Period in seconds during when a time-locked task can be executed right after it becomes executable
-    uint256 public override timeLockExecutionPeriod;
+    /**
+     * @dev Time-locks supports different frequency modes
+     * @param Seconds To indicate the execution must occur every certain number of seconds
+     * @param OnDay To indicate the execution must occur on day number from 1 to 28
+     * @param OnLastMonthDay To indicate the execution must occur on the last day of the month
+     * @param EverySomeMonths To indicate the execution must occur every certain number of months
+     */
+    enum Mode {
+        Seconds,
+        OnDay,
+        OnLastMonthDay,
+        EverySomeMonths
+    }
+
+    // Time lock mode
+    Mode internal _mode;
+
+    // Time lock frequency
+    uint256 internal _frequency;
+
+    // Future timestamp since when the task can be executed
+    uint256 internal _allowedAt;
+
+    // Next future timestamp since when the task can be executed to be set, only used internally
+    uint256 internal _nextAllowedAt;
+
+    // Period in seconds during when a time-locked task can be executed since the allowed timestamp
+    uint256 internal _window;
 
     /**
      * @dev Time lock config params. Only used in the initializer.
-     * @param delay Period in seconds that must pass after a task has been executed
-     * @param nextExecutionTimestamp Next time when the task can be executed
-     * @param executionPeriod Period in seconds during when a time-locked task can be executed
+     * @param mode Time lock mode
+     * @param frequency Time lock frequency value
+     * @param allowedAt Time lock allowed date
+     * @param window Time lock execution window
      */
     struct TimeLockConfig {
-        uint256 delay;
-        uint256 nextExecutionTimestamp;
-        uint256 executionPeriod;
+        uint8 mode;
+        uint256 frequency;
+        uint256 allowedAt;
+        uint256 window;
     }
 
     /**
@@ -55,54 +83,86 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
      * @param config Time locked task config
      */
     function __TimeLockedTask_init_unchained(TimeLockConfig memory config) internal onlyInitializing {
-        _setTimeLockDelay(config.delay);
-        _setTimeLockExpiration(config.nextExecutionTimestamp);
-        _setTimeLockExecutionPeriod(config.executionPeriod);
+        _setTimeLock(config.mode, config.frequency, config.allowedAt, config.window);
     }
 
     /**
-     * @dev Sets the time-lock delay
-     * @param delay New delay to be set
+     * @dev Tells the time-lock related information
      */
-    function setTimeLockDelay(uint256 delay) external override authP(authParams(delay)) {
-        _setTimeLockDelay(delay);
+    function getTimeLock() external view returns (uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window) {
+        return (uint8(_mode), _frequency, _allowedAt, _window);
     }
 
     /**
-     * @dev Sets the time-lock expiration timestamp
-     * @param expiration New expiration timestamp to be set
+     * @dev Sets a new time lock
      */
-    function setTimeLockExpiration(uint256 expiration) external override authP(authParams(expiration)) {
-        _setTimeLockExpiration(expiration);
-    }
-
-    /**
-     * @dev Sets the time-lock execution period
-     * @param period New execution period to be set
-     */
-    function setTimeLockExecutionPeriod(uint256 period) external override authP(authParams(period)) {
-        _setTimeLockExecutionPeriod(period);
-    }
-
-    /**
-     * @dev Tells the number of delay periods passed between the last expiration timestamp and the current timestamp
-     */
-    function _getDelayPeriods() internal view returns (uint256) {
-        uint256 diff = block.timestamp - timeLockExpiration;
-        return diff / timeLockDelay;
+    function setTimeLock(uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window)
+        external
+        override
+        authP(authParams(mode, frequency, allowedAt, window))
+    {
+        _setTimeLock(mode, frequency, allowedAt, window);
     }
 
     /**
      * @dev Before time locked task hook
      */
     function _beforeTimeLockedTask(address, uint256) internal virtual {
-        if (block.timestamp < timeLockExpiration) revert TaskTimeLockNotExpired(timeLockExpiration, block.timestamp);
+        // Load storage variables
+        Mode mode = _mode;
+        uint256 frequency = _frequency;
+        uint256 allowedAt = _allowedAt;
+        uint256 window = _window;
 
-        if (timeLockExecutionPeriod > 0) {
-            uint256 diff = block.timestamp - timeLockExpiration;
-            uint256 periods = diff / timeLockDelay;
-            uint256 offset = diff - (periods * timeLockDelay);
-            if (offset > timeLockExecutionPeriod) revert TaskTimeLockWaitNextPeriod(offset, timeLockExecutionPeriod);
+        // First we check the current timestamp is not in the past
+        if (block.timestamp < allowedAt) revert TaskTimeLockActive(block.timestamp, allowedAt);
+
+        if (mode == Mode.Seconds) {
+            if (frequency == 0) return;
+
+            // If no window is set, the next allowed date is simply moved the number of seconds set as frequency.
+            // Otherwise, the offset must be validated and the next allowed date is set to the next period.
+            if (window == 0) _nextAllowedAt = block.timestamp + frequency;
+            else {
+                uint256 diff = block.timestamp - allowedAt;
+                uint256 periods = diff / frequency;
+                uint256 offset = diff - (periods * frequency);
+                if (offset > window) revert TaskTimeLockActive(block.timestamp, allowedAt);
+                _nextAllowedAt = allowedAt + ((periods + 1) * frequency);
+            }
+        } else {
+            uint256 day;
+            uint256 monthsToAdd;
+
+            if (mode == Mode.EverySomeMonths) {
+                // Check the difference in months matches the frequency value
+                uint256 diff = allowedAt.diffMonths(block.timestamp);
+                if (diff % frequency != 0) revert TaskTimeLockActive(block.timestamp, allowedAt);
+                day = allowedAt.getDay();
+                monthsToAdd = frequency;
+            } else {
+                if (mode == Mode.OnDay) {
+                    day = allowedAt.getDay();
+                } else if (mode == Mode.OnLastMonthDay) {
+                    day = block.timestamp.getDaysInMonth();
+                } else {
+                    revert TaskInvalidFrequencyMode(uint8(mode));
+                }
+
+                // Check the current day matches the one in the configuration
+                if (block.timestamp.getDay() != day) revert TaskTimeLockActive(block.timestamp, allowedAt);
+                monthsToAdd = 1;
+            }
+
+            // Construct when would be the current allowed timestamp only considering the current month and year
+            uint256 currentAllowedAt = _getCurrentAllowedDateForMonthlyRelativeFrequency(allowedAt, day);
+
+            // Since we already checked the current timestamp is not before the allowed timestamp set,
+            // we simply need to check we are withing the allowed execution window
+            if (block.timestamp - currentAllowedAt > window) revert TaskTimeLockActive(block.timestamp, allowedAt);
+
+            // Finally set the next allowed date to the corresponding number of months from the current date
+            _nextAllowedAt = _getNextAllowedDateForMonthlyRelativeFrequency(currentAllowedAt, monthsToAdd);
         }
     }
 
@@ -110,45 +170,118 @@ abstract contract TimeLockedTask is ITimeLockedTask, Authorized {
      * @dev After time locked task hook
      */
     function _afterTimeLockedTask(address, uint256) internal virtual {
-        if (timeLockDelay > 0) {
-            uint256 nextExpirationTimestamp;
-            if (timeLockExpiration == 0) {
-                nextExpirationTimestamp = block.timestamp + timeLockDelay;
-            } else {
-                uint256 diff = block.timestamp - timeLockExpiration;
-                uint256 nextPeriod = (diff / timeLockDelay) + 1;
-                nextExpirationTimestamp = timeLockExpiration + (nextPeriod * timeLockDelay);
+        if (_nextAllowedAt == 0) return;
+        _setTimeLockAllowedAt(_nextAllowedAt);
+        _nextAllowedAt = 0;
+    }
+
+    /**
+     * @dev Sets a new time lock
+     */
+    function _setTimeLock(uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window) internal {
+        if (mode == uint8(Mode.Seconds)) {
+            // The execution window and timestamp are optional, but both must be given or none
+            // If given the execution window cannot be larger than the number of seconds
+            // Also, if these are given the frequency must be checked as well, otherwise it could be unsetting the lock
+            if (window > 0 || allowedAt > 0) {
+                if (frequency == 0) revert TaskInvalidFrequency(mode, frequency);
+                if (window == 0 || window > frequency) revert TaskInvalidAllowedWindow(mode, window);
+                if (allowedAt == 0) revert TaskInvalidAllowedDate(mode, allowedAt);
             }
-            _setTimeLockExpiration(nextExpirationTimestamp);
+        } else if (mode == uint8(Mode.OnDay)) {
+            // It must be valid for every month, then the frequency value cannot be larger than 28 days
+            if (frequency == 0 || frequency > 28) revert TaskInvalidFrequency(mode, frequency);
+
+            // The execution window that cannot be larger than 28 days
+            if (window == 0 || window > DAYS_28) revert TaskInvalidAllowedWindow(mode, window);
+
+            // The allowed date must match the specified frequency value
+            if (allowedAt == 0 || allowedAt.getDay() != frequency) revert TaskInvalidAllowedDate(mode, allowedAt);
+        } else if (mode == uint8(Mode.OnLastMonthDay)) {
+            // There must be no frequency value in this case
+            if (frequency != 0) revert TaskInvalidFrequency(mode, frequency);
+
+            // The execution window that cannot be larger than 28 days
+            if (window == 0 || window > DAYS_28) revert TaskInvalidAllowedWindow(mode, window);
+
+            // The allowed date timestamp must be the last day of the month
+            if (allowedAt == 0) revert TaskInvalidAllowedDate(mode, allowedAt);
+            if (allowedAt.getDay() != allowedAt.getDaysInMonth()) revert TaskInvalidAllowedDate(mode, allowedAt);
+        } else if (mode == uint8(Mode.EverySomeMonths)) {
+            // There is no limit on the number of months
+            if (frequency == 0) revert TaskInvalidFrequency(mode, frequency);
+
+            // The execution window cannot be larger than the number of months considering months of 28 days
+            if (window == 0 || window > frequency * DAYS_28) revert TaskInvalidAllowedWindow(mode, window);
+
+            // The execution allowed at timestamp and the day cannot be greater than the 28th
+            if (allowedAt == 0 || allowedAt.getDay() > 28) revert TaskInvalidAllowedDate(mode, allowedAt);
+        } else {
+            revert TaskInvalidFrequencyMode(mode);
         }
+
+        _mode = Mode(mode);
+        _frequency = frequency;
+        _allowedAt = allowedAt;
+        _window = window;
+
+        emit TimeLockSet(mode, frequency, allowedAt, window);
     }
 
     /**
-     * @dev Sets the time-lock delay
-     * @param delay New delay to be set
+     * @dev Sets the time-lock execution allowed timestamp
+     * @param allowedAt New execution allowed timestamp to be set
      */
-    function _setTimeLockDelay(uint256 delay) internal {
-        if (delay < timeLockExecutionPeriod) revert TaskExecutionPeriodGtDelay(timeLockExecutionPeriod, delay);
-        timeLockDelay = delay;
-        emit TimeLockDelaySet(delay);
+    function _setTimeLockAllowedAt(uint256 allowedAt) internal {
+        _allowedAt = allowedAt;
+        emit TimeLockAllowedAtSet(allowedAt);
     }
 
     /**
-     * @dev Sets the time-lock expiration timestamp
-     * @param expiration New expiration timestamp to be set
+     * @dev Tells the allowed date based on a current allowed date considering the current timestamp and a specific day.
+     * It builds a new date using the current timestamp's month and year, following by the specified day, and using
+     * the current allowed date hours, minutes, and seconds.
      */
-    function _setTimeLockExpiration(uint256 expiration) internal {
-        timeLockExpiration = expiration;
-        emit TimeLockExpirationSet(expiration);
+    function _getCurrentAllowedDateForMonthlyRelativeFrequency(uint256 allowedAt, uint256 day)
+        private
+        view
+        returns (uint256)
+    {
+        (uint256 year, uint256 month, ) = block.timestamp.timestampToDate();
+        return _getAllowedDateFor(allowedAt, year, month, day);
     }
 
     /**
-     * @dev Sets the time-lock execution period
-     * @param period New execution period to be set
+     * @dev Tells the next allowed date based on a current allowed date considering a number of months to increase
      */
-    function _setTimeLockExecutionPeriod(uint256 period) internal {
-        if (period > timeLockDelay) revert TaskExecutionPeriodGtDelay(period, timeLockDelay);
-        timeLockExecutionPeriod = period;
-        emit TimeLockExecutionPeriodSet(period);
+    function _getNextAllowedDateForMonthlyRelativeFrequency(uint256 allowedAt, uint256 monthsToIncrease)
+        private
+        view
+        returns (uint256)
+    {
+        (uint256 year, uint256 month, uint256 day) = allowedAt.timestampToDate();
+        uint256 nextMonth = month + (monthsToIncrease % 12);
+        uint256 nextYear = nextMonth > month ? year : (year + 1);
+        uint256 nextDay = _mode == Mode.OnLastMonthDay ? DateTime._getDaysInMonth(nextYear, nextMonth) : day;
+        return _getAllowedDateFor(allowedAt, nextYear, nextMonth, nextDay);
+    }
+
+    /**
+     * @dev Builds an allowed date using a specific year, month, and day
+     */
+    function _getAllowedDateFor(uint256 allowedAt, uint256 year, uint256 month, uint256 day)
+        private
+        pure
+        returns (uint256)
+    {
+        return
+            DateTime.timestampFromDateTime(
+                year,
+                month,
+                day,
+                allowedAt.getHour(),
+                allowedAt.getMinute(),
+                allowedAt.getSecond()
+            );
     }
 }

--- a/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
+++ b/packages/tasks/contracts/interfaces/base/ITimeLockedTask.sol
@@ -21,65 +21,51 @@ import './IBaseTask.sol';
  */
 interface ITimeLockedTask is IBaseTask {
     /**
-     * @dev The time-lock has not expired
+     * @dev The time lock frequency mode requested is invalid
      */
-    error TaskTimeLockNotExpired(uint256 expiration, uint256 currentTimestamp);
+    error TaskInvalidFrequencyMode(uint8 mode);
 
     /**
-     * @dev The execution period has expired
+     * @dev The time lock frequency is not valid
      */
-    error TaskTimeLockWaitNextPeriod(uint256 offset, uint256 executionPeriod);
+    error TaskInvalidFrequency(uint8 mode, uint256 frequency);
 
     /**
-     * @dev The execution period is greater than the time-lock delay
+     * @dev The time lock allowed date is not valid
      */
-    error TaskExecutionPeriodGtDelay(uint256 executionPeriod, uint256 delay);
+    error TaskInvalidAllowedDate(uint8 mode, uint256 date);
 
     /**
-     * @dev Emitted every time a new time-lock delay is set
+     * @dev The time lock allowed window is not valid
      */
-    event TimeLockDelaySet(uint256 delay);
+    error TaskInvalidAllowedWindow(uint8 mode, uint256 window);
+
+    /**
+     * @dev The time lock is still active
+     */
+    error TaskTimeLockActive(uint256 currentTimestamp, uint256 expiration);
+
+    /**
+     * @dev Emitted every time a new time lock is set
+     */
+    event TimeLockSet(uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window);
 
     /**
      * @dev Emitted every time a new expiration timestamp is set
      */
-    event TimeLockExpirationSet(uint256 expiration);
+    event TimeLockAllowedAtSet(uint256 allowedAt);
 
     /**
-     * @dev Emitted every time a new execution period is set
+     * @dev Tells all the time-lock related information
      */
-    event TimeLockExecutionPeriodSet(uint256 period);
+    function getTimeLock() external view returns (uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window);
 
     /**
-     * @dev Tells the time-lock delay in seconds
+     * @dev Sets the time-lock
+     * @param mode Time lock mode
+     * @param frequency Time lock frequency
+     * @param allowedAt Future timestamp since when the task can be executed
+     * @param window Period in seconds during when a time-locked task can be executed since the allowed timestamp
      */
-    function timeLockDelay() external view returns (uint256);
-
-    /**
-     * @dev Tells the time-lock expiration timestamp
-     */
-    function timeLockExpiration() external view returns (uint256);
-
-    /**
-     * @dev Tells the time-lock execution period
-     */
-    function timeLockExecutionPeriod() external view returns (uint256);
-
-    /**
-     * @dev Sets the time-lock delay
-     * @param delay New delay to be set
-     */
-    function setTimeLockDelay(uint256 delay) external;
-
-    /**
-     * @dev Sets the time-lock expiration timestamp
-     * @param expiration New expiration timestamp to be set
-     */
-    function setTimeLockExpiration(uint256 expiration) external;
-
-    /**
-     * @dev Sets the time-lock execution period
-     * @param period New execution period to be set
-     */
-    function setTimeLockExecutionPeriod(uint256 period) external;
+    function setTimeLock(uint8 mode, uint256 frequency, uint256 allowedAt, uint256 window) external;
 }

--- a/packages/tasks/contracts/interfaces/swap/IOneInchV5Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IOneInchV5Swapper.sol
@@ -23,5 +23,5 @@ interface IOneInchV5Swapper is IBaseSwapTask {
     /**
      * @dev Execution function
      */
-    function call(address tokenIn, uint256 amountIn, uint256 minAmountOut, bytes memory data) external;
+    function call(address tokenIn, uint256 amountIn, uint256 slippage, bytes memory data) external;
 }

--- a/packages/tasks/contracts/interfaces/swap/IUniswapV2Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IUniswapV2Swapper.sol
@@ -23,5 +23,5 @@ interface IUniswapV2Swapper is IBaseSwapTask {
     /**
      * @dev Execution function
      */
-    function call(address tokenIn, uint256 amountIn, uint256 minAmountOut, address[] memory hopTokens) external;
+    function call(address tokenIn, uint256 amountIn, uint256 slippage, address[] memory hopTokens) external;
 }

--- a/packages/tasks/contracts/interfaces/swap/IUniswapV3Swapper.sol
+++ b/packages/tasks/contracts/interfaces/swap/IUniswapV3Swapper.sol
@@ -26,7 +26,7 @@ interface IUniswapV3Swapper is IBaseSwapTask {
     function call(
         address tokenIn,
         uint256 amountIn,
-        uint256 minAmountOut,
+        uint256 slippage,
         uint24 fee,
         address[] memory hopTokens,
         uint24[] memory hopFees

--- a/packages/tasks/hardhat.config.ts
+++ b/packages/tasks/hardhat.config.ts
@@ -13,7 +13,7 @@ export default {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 10000,
+        runs: 500,
       },
     },
   },

--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -21,12 +21,13 @@
     "prepare": "yarn build"
   },
   "dependencies": {
-    "@mimic-fi/v3-authorizer": "0.1.0",
+    "@mimic-fi/v3-authorizer": "0.1.1",
     "@mimic-fi/v3-connectors": "0.1.0",
     "@mimic-fi/v3-helpers": "0.1.0",
     "@mimic-fi/v3-price-oracle": "0.1.0",
     "@mimic-fi/v3-smart-vault": "0.1.0",
-    "@openzeppelin/contracts": "4.9.3"
+    "@openzeppelin/contracts": "4.9.3",
+    "@quant-finance/solidity-datetime": "2.2.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.3",

--- a/packages/tasks/src/setup.ts
+++ b/packages/tasks/src/setup.ts
@@ -80,9 +80,10 @@ export type TaskConfig = {
     txCostLimitPct: BigNumberish
   }
   timeLockConfig: {
-    delay: BigNumberish
-    nextExecutionTimestamp: BigNumberish
-    executionPeriod: BigNumberish
+    mode: BigNumberish
+    frequency: BigNumberish
+    allowedAt: BigNumberish
+    window: BigNumberish
   }
   tokenIndexConfig: {
     acceptanceType: BigNumberish
@@ -128,9 +129,10 @@ export function buildEmptyTaskConfig(owner: SignerWithAddress, smartVault: Contr
       txCostLimitPct: 0,
     },
     timeLockConfig: {
-      delay: 0,
-      nextExecutionTimestamp: 0,
-      executionPeriod: 0,
+      mode: 0,
+      frequency: 0,
+      allowedAt: 0,
+      window: 0,
     },
     tokenIndexConfig: {
       acceptanceType: 0,

--- a/packages/tasks/test/base/TimeLockedTask.test.ts
+++ b/packages/tasks/test/base/TimeLockedTask.test.ts
@@ -8,7 +8,6 @@ import {
   getSigners,
   HOUR,
   MINUTE,
-  setNextBlockTimestamp,
   ZERO_BYTES32,
 } from '@mimic-fi/v3-helpers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
@@ -385,11 +384,29 @@ describe('TimeLockedTask', () => {
       task = task.connect(owner)
     })
 
-    async function assertItCannotBeExecuted() {
-      await expect(task.call()).to.be.revertedWith('TaskTimeLockActive')
+    async function setInitialTimeLock(mode: number, frequency: BigNumberish, timestamp: string, window: number) {
+      const allowedAt = new Date(timestamp).getTime() / 1000
+      await task.setTimeLock(mode, frequency, allowedAt, window)
     }
 
-    async function assertItCanBeExecuted(expectedNextAllowedDate: BigNumberish) {
+    async function moveToDate(timestamp: string, delta = 0): Promise<void> {
+      const date = new Date(timestamp).getTime() / 1000
+      const now = await currentTimestamp()
+      const diff = date - now.toNumber() + delta
+      await advanceTime(diff)
+    }
+
+    async function assertItCannotBeExecuted(currentAllowedTimestamp: string) {
+      await expect(task.call()).to.be.revertedWith('TaskTimeLockActive')
+
+      const expectedCurrentAllowedDate = new Date(currentAllowedTimestamp).getTime() / 1000
+      const { allowedAt } = await task.getTimeLock()
+      expect(allowedAt).to.be.equal(expectedCurrentAllowedDate)
+    }
+
+    async function assertItCanBeExecuted(nextAllowedTimestamp: string) {
+      const expectedNextAllowedDate = new Date(nextAllowedTimestamp).getTime() / 1000
+
       const tx = await task.call()
       await assertEvent(tx, 'TimeLockAllowedAtSet', { allowedAt: expectedNextAllowedDate })
 
@@ -397,91 +414,67 @@ describe('TimeLockedTask', () => {
       expect(allowedAt).to.be.equal(expectedNextAllowedDate)
     }
 
-    async function moveToDate(timestamp: string, delta = 0): Promise<void> {
-      const date = new Date(`${timestamp}T00:00:00Z`).getTime() / 1000
-      const now = await currentTimestamp()
-      const diff = date - now.toNumber() + delta
-      await advanceTime(diff)
-    }
-
     context('seconds mode', () => {
       const mode = MODE.SECONDS
       const frequency = HOUR * 2
-
-      async function getNextAllowedDate(delayed: number) {
-        const previousTimeLock = await task.getTimeLock()
-        const now = await currentTimestamp()
-        return (previousTimeLock.window.eq(0) ? now : previousTimeLock.allowedAt).add(delayed)
-      }
 
       context('without execution window', () => {
         const window = 0
         const allowedAt = 0
 
-        beforeEach('set time lock', async () => {
-          await task.setTimeLock(mode, frequency, allowedAt, window)
-        })
-
         it('locks the task properly', async () => {
           // It can be executed immediately
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency + 1))
+          await task.setTimeLock(mode, frequency, allowedAt, window)
+          await moveToDate('2025-01-01T10:20:29Z')
+          await assertItCanBeExecuted('2025-01-01T12:20:30Z')
 
           // It is locked for a period equal to the frequency set
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency / 2)
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency / 2)
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency + 1))
+          await assertItCannotBeExecuted('2025-01-01T12:20:30Z')
+          await moveToDate('2025-01-01T11:20:30Z')
+          await assertItCannotBeExecuted('2025-01-01T12:20:30Z')
+          await moveToDate('2025-01-01T12:20:29Z')
+          await assertItCanBeExecuted('2025-01-01T14:20:30Z')
 
           // It is locked for a period equal to the frequency set again
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency - 10)
-          await assertItCannotBeExecuted()
+          await assertItCannotBeExecuted('2025-01-01T14:20:30Z')
+          await moveToDate('2025-01-01T14:20:28Z')
+          await assertItCannotBeExecuted('2025-01-01T14:20:30Z')
 
           // It can be executed at any point in time in the future
-          await advanceTime(frequency * 1000)
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency + 1))
+          await moveToDate('2026-01-01T01:02:03Z')
+          await assertItCanBeExecuted('2026-01-01T03:02:04Z')
         })
       })
 
       context('with execution window', () => {
         const window = MINUTE * 30
-        const allowedAt = new Date('2023-10-05').getTime() / 1000
-
-        beforeEach('set time lock', async () => {
-          await task.setTimeLock(mode, frequency, allowedAt, window)
-        })
+        const allowedAt = new Date('2026-06-01T08:22:34Z').getTime() / 1000
 
         it('locks the task properly', async () => {
-          // Move to an executable window
-          const now = await currentTimestamp()
-          const periods = now.sub(allowedAt).div(frequency).toNumber()
-          const nextAllowedDate = allowedAt + (periods + 1) * frequency
-          await setNextBlockTimestamp(nextAllowedDate)
-
           // It can be executed immediately
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency * (periods + 2)))
+          await task.setTimeLock(mode, frequency, allowedAt, window)
+          await moveToDate('2026-06-01T08:22:34Z')
+          await assertItCanBeExecuted('2026-06-01T10:22:34Z')
 
           // It is locked for a period equal to the frequency set
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency / 2)
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency / 2)
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency))
+          await assertItCannotBeExecuted('2026-06-01T10:22:34Z')
+          await moveToDate('2026-06-01T09:22:34Z')
+          await assertItCannotBeExecuted('2026-06-01T10:22:34Z')
+          await moveToDate('2026-06-01T10:22:34Z')
+          await assertItCanBeExecuted('2026-06-01T12:22:34Z')
 
           // It is locked for a period equal to the frequency set again
-          await assertItCannotBeExecuted()
-          await advanceTime(frequency - 10)
-          await assertItCannotBeExecuted()
+          await assertItCannotBeExecuted('2026-06-01T12:22:34Z')
+          await moveToDate('2026-06-01T12:20:34Z')
+          await assertItCannotBeExecuted('2026-06-01T12:22:34Z')
 
           // It cannot be executed after the execution window
-          const timeLock = await task.getTimeLock()
-          await setNextBlockTimestamp(timeLock.allowedAt.add(window).add(1))
-          await assertItCannotBeExecuted()
+          await moveToDate('2026-06-01T12:52:35Z')
+          await assertItCannotBeExecuted('2026-06-01T12:22:34Z')
 
           // It can be executed one period after
-          await setNextBlockTimestamp(timeLock.allowedAt.add(frequency))
-          await assertItCanBeExecuted(await getNextAllowedDate(frequency * 2))
+          await moveToDate('2026-06-01T14:22:34Z')
+          await assertItCanBeExecuted('2026-06-01T16:22:34Z')
         })
       })
     })
@@ -489,124 +482,86 @@ describe('TimeLockedTask', () => {
     context('on-day mode', () => {
       const mode = MODE.ON_DAY
       const frequency = 5
-      const allowedAt = new Date('2028-10-05T00:00:00Z').getTime() / 1000
       const window = 1 * DAY
-
-      beforeEach('set time lock', async () => {
-        await task.setTimeLock(mode, frequency, allowedAt, window)
-      })
-
-      async function getNextAllowedDate(): Promise<number> {
-        const now = new Date((await currentTimestamp()).toNumber() * 1000)
-        const month = now.getMonth()
-        const nextMonth = (month + 1) % 12
-        const nextYear = nextMonth > month ? now.getFullYear() : now.getFullYear() + 1
-        return new Date(`${nextYear}-${(nextMonth + 1).toString().padStart(2, '0')}-05T00:00:00Z`).getTime() / 1000
-      }
 
       it('locks the task properly', async () => {
         // Move to an executable window
-        await moveToDate('2028-10-05')
+        await setInitialTimeLock(mode, frequency, '2028-10-05T01:02:03Z', window)
+        await moveToDate('2028-10-05T01:02:03Z')
 
         // It can be executed immediately
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await assertItCanBeExecuted('2028-11-05T01:02:03Z')
 
         // It is locked for at least a month
-        await assertItCannotBeExecuted()
-        await moveToDate('2028-10-20')
-        await assertItCannotBeExecuted()
+        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
+        await moveToDate('2028-10-20T01:02:03Z')
+        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
 
         // It cannot be executed after the execution window
-        await moveToDate('2028-11-05', window + 1)
-        await assertItCannotBeExecuted()
+        await moveToDate('2028-11-06T01:02:03Z')
+        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
 
         // It can be executed one period after
-        await moveToDate('2028-12-05', window - 10)
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await moveToDate('2028-12-05T01:02:03Z')
+        await assertItCanBeExecuted('2029-01-05T01:02:03Z')
       })
     })
 
     context('on-last-day mode', () => {
       const mode = MODE.ON_LAST_DAY
       const frequency = 0
-      const allowedAt = new Date('2030-10-31T00:00:00Z').getTime() / 1000
       const window = 1 * DAY
-
-      beforeEach('set time lock', async () => {
-        await task.setTimeLock(mode, frequency, allowedAt, window)
-      })
-
-      async function getNextAllowedDate(): Promise<number> {
-        const now = new Date((await currentTimestamp()).toNumber() * 1000)
-        const month = now.getMonth()
-        const nextMonth = (month + 1) % 12
-        const nextYear = nextMonth > month ? now.getFullYear() : now.getFullYear() + 1
-        const lastDayOfMonth = new Date(nextYear, nextMonth + 1, 0).getDate()
-        const date = `${nextYear}-${(nextMonth + 1).toString().padStart(2, '0')}-${lastDayOfMonth}T00:00:00Z`
-        return new Date(date).getTime() / 1000
-      }
 
       it('locks the task properly', async () => {
         // Move to an executable window
-        await moveToDate('2030-10-31')
+        await setInitialTimeLock(mode, frequency, '2030-10-31T10:32:20Z', window)
+        await moveToDate('2030-10-31T10:32:20Z')
 
         // It can be executed immediately
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await assertItCanBeExecuted('2030-11-30T10:32:20Z')
 
         // It is locked for at least a month
-        await assertItCannotBeExecuted()
-        await moveToDate('2030-11-20')
-        await assertItCannotBeExecuted()
+        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
+        await moveToDate('2030-11-20T10:32:20Z')
+        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
 
         // It cannot be executed after the execution window
-        await moveToDate('2030-12-31', window + 1)
-        await assertItCannotBeExecuted()
+        await moveToDate('2031-01-01T10:32:20Z')
+        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
 
         // It can be executed one period after
-        await moveToDate('2031-01-31', window - 10)
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await moveToDate('2031-01-31T10:32:20Z')
+        await assertItCanBeExecuted('2031-02-28T10:32:20Z')
       })
     })
 
     context('every-month mode', () => {
       const mode = MODE.EVERY_X_MONTH
-      const frequency = 3
-      const allowedAt = new Date('2032-10-06T00:00:00Z').getTime() / 1000
+      const frequency = 2
       const window = 1 * DAY
-
-      beforeEach('set time lock', async () => {
-        await task.setTimeLock(mode, frequency, allowedAt, window)
-      })
-
-      async function getNextAllowedDate(): Promise<number> {
-        const now = new Date((await currentTimestamp()).toNumber() * 1000)
-        const month = now.getMonth()
-        const nextMonth = (month + frequency) % 12
-        const nextYear = nextMonth > month ? now.getFullYear() : now.getFullYear() + 1
-        return new Date(`${nextYear}-${(nextMonth + 1).toString().padStart(2, '0')}-06T00:00:00Z`).getTime() / 1000
-      }
 
       it('locks the task properly', async () => {
         // Move to an executable window
-        await moveToDate('2032-10-06')
+        await setInitialTimeLock(mode, frequency, '2032-01-01T10:05:20Z', window)
+        await moveToDate('2032-01-01T10:05:20Z')
 
         // It can be executed immediately
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await assertItCanBeExecuted('2032-03-01T10:05:20Z')
 
         // It is locked for at least the number of set months
-        await assertItCannotBeExecuted()
-        await moveToDate('2032-11-06')
-        await assertItCannotBeExecuted()
-        await moveToDate('2032-12-06')
-        await assertItCannotBeExecuted()
+        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+        await moveToDate('2032-02-01T10:05:20Z')
+        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+        await moveToDate('2032-02-28T10:05:20Z')
+        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
 
         // It cannot be executed after the execution window
-        await moveToDate('2033-01-06', window + 1)
-        await assertItCannotBeExecuted()
+        await moveToDate('2032-03-02T10:05:21Z')
+        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
 
         // It can be executed one period after
-        await moveToDate('2033-04-06', window - 1)
-        await assertItCanBeExecuted(await getNextAllowedDate())
+        await moveToDate('2032-05-02T10:05:19Z')
+        await assertItCanBeExecuted('2032-07-01T10:05:20Z')
       })
     })
   })

--- a/packages/tasks/test/base/TimeLockedTask.test.ts
+++ b/packages/tasks/test/base/TimeLockedTask.test.ts
@@ -177,52 +177,56 @@ describe('TimeLockedTask', () => {
         const mode = MODE.ON_DAY
 
         context('when a frequency is given', () => {
-          context('when the frequency is lower than or equal to 28', () => {
-            const frequency = 28
+          const frequency = 10
 
-            context('when a window is given', () => {
-              context('when the window is shorter than the frequency', () => {
-                const window = frequency * DAY - 1
+          context('when a window is given', () => {
+            context('when the window is shorter than months of 28 days', () => {
+              const window = frequency * DAY * 28 - 1
 
-                context('when an allowed date is given', () => {
-                  context('when the allowed day matches the frequency', () => {
-                    const allowedAt = new Date(`2023-10-${frequency}`).getTime() / 1000
+              context('when an allowed date is given', () => {
+                context('when the allowed date day is lower than or equal to 28', () => {
+                  const allowedDates = ['2022-06-01', '2023-10-11', '2021-12-21', '2020-02-28']
 
-                    itSetsTheTimeLockProperly(mode, frequency, allowedAt, window)
-                  })
+                  allowedDates.forEach((date) => {
+                    context(`for ${date}`, () => {
+                      const allowedAt = new Date(date).getTime() / 1000
 
-                  context('when the allowed day does not match the frequency', () => {
-                    const allowedAt = new Date(`2023-10-${frequency + 1}`).getTime() / 1000
-
-                    itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
+                      itSetsTheTimeLockProperly(mode, frequency, allowedAt, window)
+                    })
                   })
                 })
 
-                context('when no allowed date is given', () => {
-                  const allowedAt = 0
+                context('when the allowed date day is not greater than 28', () => {
+                  const notAllowedDates = ['2022-08-30', '2032-02-29', '2020-07-31']
 
-                  itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
+                  notAllowedDates.forEach((date) => {
+                    context(`for ${date}`, () => {
+                      const allowedAt = new Date(date).getTime() / 1000
+
+                      itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
+                    })
+                  })
                 })
               })
 
-              context('when the window is larger than the frequency', () => {
-                const window = frequency * DAY + 1
+              context('when no allowed date is given', () => {
+                const allowedAt = 0
 
-                itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
+                itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
               })
             })
 
-            context('when no window is given', () => {
-              const window = 0
+            context('when the window is larger than months of 28 days', () => {
+              const window = frequency * DAY * 28 + 1
 
               itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
             })
           })
 
-          context('when the frequency is greater than 28', () => {
-            const frequency = 29
+          context('when no window is given', () => {
+            const window = 0
 
-            itReverts(mode, frequency, 0, 0, 'TaskInvalidFrequency')
+            itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
           })
         })
 
@@ -237,17 +241,11 @@ describe('TimeLockedTask', () => {
         const mode = MODE.ON_LAST_DAY
 
         context('when a frequency is given', () => {
-          const frequency = 1
-
-          itReverts(mode, frequency, 0, 0, 'TaskInvalidFrequency')
-        })
-
-        context('when no frequency is given', () => {
-          const frequency = 0
+          const frequency = 10
 
           context('when a window is given', () => {
-            context('when the window is shorter than 28 days', () => {
-              const window = 28 * DAY - 1
+            context('when the window is shorter than months of 28 days', () => {
+              const window = 28 * DAY * frequency - 1
 
               context('when an allowed date is given', () => {
                 context('when the allowed date is a last day of a month', () => {
@@ -283,64 +281,6 @@ describe('TimeLockedTask', () => {
             })
 
             context('when the window is larger than 28 days', () => {
-              const window = 28 * DAY + 1
-
-              itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
-            })
-          })
-
-          context('when no window is given', () => {
-            const window = 0
-
-            itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
-          })
-        })
-      })
-
-      context('every-month mode', () => {
-        const mode = MODE.EVERY_X_MONTH
-
-        context('when a frequency is given', () => {
-          const frequency = 3
-
-          context('when a window is given', () => {
-            context('when the window is shorter than months of 28 days', () => {
-              const window = 28 * DAY * frequency - 1
-
-              context('when an allowed date is given', () => {
-                context('when the allowed day is lower than or equal to 28', () => {
-                  const allowedDates = ['2022-06-10', '2023-10-01', '2021-02-28']
-
-                  allowedDates.forEach((date) => {
-                    context(`for ${date}`, () => {
-                      const allowedAt = new Date(date).getTime() / 1000
-
-                      itSetsTheTimeLockProperly(mode, frequency, allowedAt, window)
-                    })
-                  })
-                })
-
-                context('when the allowed day is greater than 28', () => {
-                  const notAllowedDates = ['2022-08-30', '2020-02-29', '2023-10-31', '2023-06-30']
-
-                  notAllowedDates.forEach((date) => {
-                    context(`for ${date}`, () => {
-                      const allowedAt = new Date(date).getTime() / 1000
-
-                      itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
-                    })
-                  })
-                })
-              })
-
-              context('when no allowed date is given', () => {
-                const allowedAt = 0
-
-                itReverts(mode, frequency, allowedAt, window, 'TaskInvalidAllowedDate')
-              })
-            })
-
-            context('when the window is larger than months of 28 days', () => {
               const window = 28 * DAY * frequency + 1
 
               itReverts(mode, frequency, 0, window, 'TaskInvalidAllowedWindow')
@@ -484,88 +424,132 @@ describe('TimeLockedTask', () => {
     context('on-day mode', () => {
       const mode = MODE.ON_DAY
 
-      it('locks the task properly', async () => {
-        // Move to an executable window
-        await setInitialTimeLock(mode, 5, '2028-10-05T01:02:03Z', DAY)
-        await moveToDate('2028-10-05T01:02:03Z')
+      context('with 1 month frequency', () => {
+        const frequency = 1
 
-        // It can be executed immediately
-        await assertItCanBeExecuted('2028-11-05T01:02:03Z')
+        it('locks the task properly', async () => {
+          // Move to an executable window
+          await setInitialTimeLock(mode, frequency, '2028-10-05T01:02:03Z', DAY)
+          await moveToDate('2028-10-05T01:02:03Z')
 
-        // It is locked for at least a month
-        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
-        await moveToDate('2028-10-20T01:02:03Z')
-        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
+          // It can be executed immediately
+          await assertItCanBeExecuted('2028-11-05T01:02:03Z')
 
-        // It cannot be executed after the execution window
-        await moveToDate('2028-11-06T01:02:03Z')
-        await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
+          // It is locked for at least a month
+          await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
+          await moveToDate('2028-10-20T01:02:03Z')
+          await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
 
-        // It can be executed one period after
-        await moveToDate('2028-12-05T01:02:03Z')
-        await assertItCanBeExecuted('2029-01-05T01:02:03Z')
+          // It cannot be executed after the execution window
+          await moveToDate('2028-11-06T01:02:03Z')
+          await assertItCannotBeExecuted('2028-11-05T01:02:03Z')
+
+          // It can be executed one period after
+          await moveToDate('2028-12-05T01:02:03Z')
+          await assertItCanBeExecuted('2029-01-05T01:02:03Z')
+        })
+      })
+
+      context('with 2 months frequency', () => {
+        const frequency = 2
+
+        it('locks the task properly', async () => {
+          // Move to an executable window
+          await setInitialTimeLock(mode, frequency, '2032-01-01T10:05:20Z', DAY)
+          await moveToDate('2032-01-01T10:05:20Z')
+
+          // It can be executed immediately
+          await assertItCanBeExecuted('2032-03-01T10:05:20Z')
+
+          // It is locked for at least the number of set months
+          await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+          await moveToDate('2032-02-01T10:05:20Z')
+          await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+          await moveToDate('2032-02-28T10:05:20Z')
+          await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+
+          // It cannot be executed after the execution window
+          await moveToDate('2032-03-02T10:05:21Z')
+          await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+
+          // It can be executed one period after
+          await moveToDate('2032-05-02T10:05:19Z')
+          await assertItCanBeExecuted('2032-07-01T10:05:20Z')
+
+          // Change time lock to 24 months
+          await setInitialTimeLock(mode, 24, '2033-01-01T05:04:03Z', DAY)
+          await assertItCannotBeExecuted('2033-01-01T05:04:03Z')
+
+          // Move to an executable window
+          await moveToDate('2033-01-01T05:04:03Z')
+          await assertItCanBeExecuted('2035-01-01T05:04:03Z')
+        })
       })
     })
 
     context('on-last-day mode', () => {
       const mode = MODE.ON_LAST_DAY
 
-      it('locks the task properly', async () => {
-        // Move to an executable window
-        await setInitialTimeLock(mode, 0, '2030-10-31T10:32:20Z', DAY)
-        await moveToDate('2030-10-31T10:32:20Z')
+      context('with 1 month frequency', () => {
+        const frequency = 1
 
-        // It can be executed immediately
-        await assertItCanBeExecuted('2030-11-30T10:32:20Z')
+        it('locks the task properly', async () => {
+          // Move to an executable window
+          await setInitialTimeLock(mode, frequency, '2030-10-31T10:32:20Z', DAY)
+          await moveToDate('2030-10-31T10:32:20Z')
 
-        // It is locked for at least a month
-        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
-        await moveToDate('2030-11-20T10:32:20Z')
-        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
+          // It can be executed immediately
+          await assertItCanBeExecuted('2030-11-30T10:32:20Z')
 
-        // It cannot be executed after the execution window
-        await moveToDate('2031-01-01T10:32:20Z')
-        await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
+          // It is locked for at least a month
+          await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
+          await moveToDate('2030-11-20T10:32:20Z')
+          await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
 
-        // It can be executed one period after
-        await moveToDate('2031-01-31T10:32:20Z')
-        await assertItCanBeExecuted('2031-02-28T10:32:20Z')
+          // It cannot be executed after the execution window
+          await moveToDate('2031-01-01T10:32:20Z')
+          await assertItCannotBeExecuted('2030-11-30T10:32:20Z')
+
+          // It can be executed one period after
+          await moveToDate('2031-01-31T10:32:20Z')
+          await assertItCanBeExecuted('2031-02-28T10:32:20Z')
+        })
       })
-    })
 
-    context('every-month mode', () => {
-      const mode = MODE.EVERY_X_MONTH
+      context('with 3 months frequency', () => {
+        const frequency = 3
 
-      it('locks the task properly', async () => {
-        // Move to an executable window
-        await setInitialTimeLock(mode, 2, '2032-01-01T10:05:20Z', DAY)
-        await moveToDate('2032-01-01T10:05:20Z')
+        it('locks the task properly', async () => {
+          // Move to an executable window
+          await setInitialTimeLock(mode, frequency, '2032-01-31T10:05:20Z', DAY)
+          await moveToDate('2032-01-31T10:05:20Z')
 
-        // It can be executed immediately
-        await assertItCanBeExecuted('2032-03-01T10:05:20Z')
+          // It can be executed immediately
+          await assertItCanBeExecuted('2032-04-30T10:05:20Z')
 
-        // It is locked for at least the number of set months
-        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
-        await moveToDate('2032-02-01T10:05:20Z')
-        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
-        await moveToDate('2032-02-28T10:05:20Z')
-        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+          // It is locked for at least the number of set months
+          await assertItCannotBeExecuted('2032-04-30T10:05:20Z')
+          await moveToDate('2032-02-28T10:05:20Z')
+          await assertItCannotBeExecuted('2032-04-30T10:05:20Z')
+          await moveToDate('2032-03-31T10:05:20Z')
+          await assertItCannotBeExecuted('2032-04-30T10:05:20Z')
 
-        // It cannot be executed after the execution window
-        await moveToDate('2032-03-02T10:05:21Z')
-        await assertItCannotBeExecuted('2032-03-01T10:05:20Z')
+          // It cannot be executed after the execution window
+          await moveToDate('2032-05-01T10:05:20Z')
+          await assertItCannotBeExecuted('2032-04-30T10:05:20Z')
 
-        // It can be executed one period after
-        await moveToDate('2032-05-02T10:05:19Z')
-        await assertItCanBeExecuted('2032-07-01T10:05:20Z')
+          // It can be executed one period after
+          await moveToDate('2032-06-30T10:05:20Z')
+          await assertItCanBeExecuted('2032-09-30T10:05:20Z')
 
-        // Change time lock to 24 months
-        await setInitialTimeLock(mode, 24, '2033-01-01T05:04:03Z', DAY)
-        await assertItCannotBeExecuted('2033-01-01T05:04:03Z')
+          // Change time lock to 24 months
+          await setInitialTimeLock(mode, 24, '2033-01-31T05:04:03Z', DAY)
+          await assertItCannotBeExecuted('2033-01-31T05:04:03Z')
 
-        // Move to an executable window
-        await moveToDate('2033-01-01T05:04:03Z')
-        await assertItCanBeExecuted('2035-01-01T05:04:03Z')
+          // Move to an executable window
+          await moveToDate('2033-01-31T05:04:03Z')
+          await assertItCanBeExecuted('2035-01-31T05:04:03Z')
+        })
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,14 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@mimic-fi/v3-authorizer@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mimic-fi/v3-authorizer/-/v3-authorizer-0.1.0.tgz#10fa3b9c5ac7c3ab95d6c77764376a6707703d09"
+  integrity sha512-iuJH2u2a73WS4mHj/W6xjl/tqkKB4upRnSKlN8E1YcpE0waVZwSk6vlX5ANPPkYnWzNbaX89y4pQUNjC5cLB+A==
+  dependencies:
+    "@mimic-fi/v3-helpers" "0.1.0"
+    "@openzeppelin/contracts" "4.7.0"
+
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
@@ -1157,10 +1165,20 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
   integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
 
+"@openzeppelin/contracts@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
+  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
+
 "@openzeppelin/contracts@4.9.3":
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
   integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
+
+"@quant-finance/solidity-datetime@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@quant-finance/solidity-datetime/-/solidity-datetime-2.2.0.tgz#50f2d00a571d8cc2d962257b40b70fc44450dcaa"
+  integrity sha512-iO0EnqPKTzGCgQOkI9lerpJc0XKUhMNurSjHcA7p7nlP2K2z3U4kk9OC9eQkZUrdBtltft+kIibiDdIOYWuQMg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
**⚠️ I still need to fix contract bytecode size**

This PR aims to provide new modes for timelocks, the alternatives now are:
- waiting at least X seconds between executions, no matter when
- waiting at least X seconds between executions, starting on date Y, with an execution window Z
- occurring every X months, on day Y, with an execution window Z
- occurring every X months, on last day of month, with an execution window Z