### PR TITLE
Chore: Use a fixed prover version

### DIFF
--- a/.github/actions/certora/action.yml
+++ b/.github/actions/certora/action.yml
@@ -25,7 +25,7 @@ runs:
       with: { java-version: '11', java-package: jre }
     - name: Install certora cli
       shell: bash
-      run: pip install certora-cli
+      run: pip install certora-cli=4.13.1
     - name: Install solc
       shell: bash
       run: |

--- a/.github/actions/certora/action.yml
+++ b/.github/actions/certora/action.yml
@@ -25,7 +25,7 @@ runs:
       with: { java-version: '11', java-package: jre }
     - name: Install certora cli
       shell: bash
-      run: pip install certora-cli=4.13.1
+      run: pip install certora-cli==4.13.1
     - name: Install solc
       shell: bash
       run: |


### PR DESCRIPTION
Certora will be introducing v5 soon, which is expected to include breaking changes. Fixing the version at v4.13.1 should allow continuity until we make changes to upgrade.